### PR TITLE
Add an "attribute" kwarg to has_outgoing_url

### DIFF
--- a/docs/pages/element-class.md
+++ b/docs/pages/element-class.md
@@ -351,19 +351,18 @@ body_structure = ChecklistItem("The body has a table followed by a div.", [
 Check that this element has a url that doesn't go to another domain, optionally with a `list` of domains that you want
 to allow.
 
-In case the element is not an `<a>`-tag or does not have an `href` attribute, this will also return `False`.
-
 #### Signature
 
 ```python
-def has_outgoing_url(allowed_domains: Optional[List[str]] = None) -> Check
+def has_outgoing_url(allowed_domains: Optional[List[str]] = None, attr: str = "href") -> Check
 ```
 
 #### Parameters
 
 | Name      | Description                                     | Required? | Default                                           |
 |:----------|:------------------------------------------------|:---------:|:--------------------------------------------------|
-| `allowed_domains`  | An optional list of domains that should *not* be considered "outgoing". |           | `None`, which will default to `["dodona.ugent.be", "users.ugent.be"]`.|
+| `allowed_domains`  | An optional list of domains that should *not* be considered "outgoing". |           | `None`, which will default to `["dodona.ugent.be", "users.ugent.be"]`. If you don't want to allow those domains either, simply pass an `empty list` (`[]`). |
+| `attr` | The attribute the link should be in, which allows this to be used on multiple types of tags. For example, `<a>`-tags (`attr="href"`) and `<img>`-tags (`attr="src"`). | | `"href"`, used in `<a>`-tags. |
 
 #### Example usage
 

--- a/validators/checks.py
+++ b/validators/checks.py
@@ -475,10 +475,11 @@ class Element:
 
         return Check(_inner)
 
-    def has_outgoing_url(self, allowed_domains: Optional[List[str]] = None) -> Check:
-        """Check if an <a>-tag has an outgoing link
+    def has_outgoing_url(self, allowed_domains: Optional[List[str]] = None, attr: str = "href") -> Check:
+        """Check if a tag has an outgoing link
         :param allowed_domains: A list of domains that should not be considered "outgoing",
                                 defaults to ["dodona.ugent.be", "users.ugent.be"]
+        :param attr:       The attribute the link should be in
         """
         if allowed_domains is None:
             allowed_domains = ["dodona.ugent.be", "users.ugent.be"]
@@ -489,11 +490,7 @@ class Element:
             if self._element is None:
                 return False
 
-            # Not an anchor tag
-            if self.tag.lower() != "a":
-                return False
-
-            url = self._get_attribute("href")
+            url = self._get_attribute(attr.lower())
 
             # No url present
             if url is None:

--- a/validators/checks.pyi
+++ b/validators/checks.pyi
@@ -110,10 +110,11 @@ class Element:
         """Check that this element has a url with a fragment (#), optionally comparing the fragment to a string that it should match exactly."""
         ...
 
-    def has_outgoing_url(self, allowed_domains: Optional[List[str]] = None) -> Check:
+    def has_outgoing_url(self, allowed_domains: Optional[List[str]] = None, attr: str = "href") -> Check:
         """Check if an <a>-tag has an outgoing link
         :param allowed_domains: A list of domains that should not be considered "outgoing",
                                 defaults to ["dodona.ugent.be", "users.ugent.be"]
+        :param attr:       The attribute the link should be in
         """
         ...
 


### PR DESCRIPTION
fixes #146 by allowing the attribute to be changed

```python
suite.element("img").has_outgoing_url(attr="src")
```
To check for `internal`, wrap `fail_if()` around it. No need to write a custom check just for that purpose.