### PR TITLE
Catch error for empty submissions

### DIFF
--- a/tests/test_utils/test_html_checks.py
+++ b/tests/test_utils/test_html_checks.py
@@ -1,0 +1,18 @@
+import unittest
+from utils import html_checks
+
+
+class TestHTMLChecks(unittest.TestCase):
+    def test_is_empty_document(self):
+        self.assertTrue(html_checks.is_empty_document(""))
+        self.assertTrue(html_checks.is_empty_document(" "))
+        self.assertTrue(html_checks.is_empty_document("\t"))
+        self.assertTrue(html_checks.is_empty_document("\n\n\n"))
+        self.assertTrue(html_checks.is_empty_document("<!-- comment-->\n"))
+        self.assertTrue(html_checks.is_empty_document("<!-- comment\n<html>\n</html> -->"))
+
+        self.assertFalse(html_checks.is_empty_document("<html></html>"))
+        self.assertFalse(html_checks.is_empty_document("  \n<html></html>\n   "))
+        self.assertFalse(html_checks.is_empty_document("<!-- comment -->\n<html></html>"))
+        self.assertFalse(html_checks.is_empty_document("<!-- comment\n<html>\n</html> --><body></body>"))
+        self.assertFalse(html_checks.is_empty_document("<html> <!-- inline comment -->\n</html>"))

--- a/utils/html_checks.py
+++ b/utils/html_checks.py
@@ -1,3 +1,6 @@
+from bs4 import BeautifulSoup
+
+
 def is_empty_document(document: str) -> bool:
     """Check if a document is empty, not allowing comments"""
     document = document.strip()
@@ -6,24 +9,13 @@ def is_empty_document(document: str) -> bool:
     if not document:
         return True
 
-    # Allow multiline comments
-    in_comment = False
+    try:
+        parsed = BeautifulSoup(document, "html.parser")
+    except Exception:
+        # The document was not empty, but it also wasn't valid
+        # the HTML validator should catch this and warn about it, ignore it here
+        return False
 
-    for line in document.splitlines():
-        line = line.strip()
-
-        # Line is empty
-        if not line:
-            continue
-
-        # New comment started
-        if line.startswith("<!--"):
-            in_comment = True
-        elif line.endswith("-->"):
-            in_comment = False
-        elif not in_comment and line.startswith("<"):
-            # At least one line was not a comment
-            return False
-
-    # Not a single line was found
-    return True
+    # Find() doesn't return comments by default, so if None comes out of this
+    # then we know that there's no content in the document
+    return parsed.find() is None

--- a/utils/html_checks.py
+++ b/utils/html_checks.py
@@ -1,0 +1,29 @@
+def is_empty_document(document: str) -> bool:
+    """Check if a document is empty, not allowing comments"""
+    document = document.strip()
+
+    # Completely empty (barring whitespace)
+    if not document:
+        return True
+
+    # Allow multiline comments
+    in_comment = False
+
+    for line in document.splitlines():
+        line = line.strip()
+
+        # Line is empty
+        if not line:
+            continue
+
+        # New comment started
+        if line.startswith("<!--"):
+            in_comment = True
+        elif line.endswith("-->"):
+            in_comment = False
+        elif not in_comment and line.startswith("<"):
+            # At least one line was not a comment
+            return False
+
+    # Not a single line was found
+    return True

--- a/validators/checks.py
+++ b/validators/checks.py
@@ -860,6 +860,11 @@ class TestSuite:
                         with Annotation(row=err.line, text=err.annotation_str(), type="error"):
                             pass
                     return False
+
+            # Empty submission is invalid HTML
+            if not self.content.strip():
+                return False
+
             # If no validation errors were raised, the HTML is valid
             self._html_validated = True
             return True

--- a/validators/checks.py
+++ b/validators/checks.py
@@ -895,14 +895,21 @@ class TestSuite:
             try:
                 compare(solution, self.content, translator, **kwargs)
             except NotTheSame as err:
-                html_sim, css_sim = get_similarity(solution, self.content)
-                html_sim_str = f"\n HTML{translator.translate(Translator.Text.SIMILARITY)}: {round(html_sim * 100)}%"
-                css_sim_str = f"\n CSS{translator.translate(Translator.Text.SIMILARITY)}: {round(css_sim* 100)}%" if css_sim != 1 else ""
-                with Message(description=f"{err.message_str()}{html_sim_str}{css_sim_str}", format=MessageFormat.CODE):
+                description = err.message_str()
+
+                # Only calculate similarity for valid HTML
+                if self._html_validated:
+                    html_sim, css_sim = get_similarity(solution, self.content)
+                    html_sim_str = f"\n Html{translator.translate(Translator.Text.SIMILARITY)}: {round(html_sim * 100)}%"
+                    css_sim_str = f"\n Css{translator.translate(Translator.Text.SIMILARITY)}: {round(css_sim* 100)}%" if css_sim != 1 else ""
+                    description += html_sim_str + css_sim_str
+
+                with Message(description=description, format=MessageFormat.CODE):
                     # Only add annotation if line number is positive
                     if err.line >= 0:
                         with Annotation(err.line, err.annotation_str()):
                             pass
+
                     return False
             return True
 

--- a/validators/structure_validator.py
+++ b/validators/structure_validator.py
@@ -9,6 +9,10 @@ from typing import Tuple
 
 
 def get_similarity(sol: str, sub: str) -> Tuple[float, float]:
+    # Empty submission is 0% similar
+    if not sub.strip():
+        return 0, 0
+
     from html_similarity import style_similarity, structural_similarity
     a = sol.find("<style")
     b = sub.find("<style")
@@ -32,7 +36,6 @@ def compare(solution_str: str, submission_str: str, trans: Translator, **kwargs)
     """
     if not submission_str.strip():
         raise NotTheSame(trans=trans, msg=trans.translate(Translator.Text.EMPTY_SUBMISSION), line=-1, pos=-1)
-
 
     # structure is always checked
     check_attributes = kwargs.get("attributes", False)

--- a/validators/structure_validator.py
+++ b/validators/structure_validator.py
@@ -4,13 +4,14 @@ from lxml.html import fromstring, HtmlElement, HtmlComment
 from exceptions.structure_exceptions import NotTheSame
 from validators.css_validator import CssValidator
 from utils.html_navigation import compare_content
+from utils.html_checks import is_empty_document
 
 from typing import Tuple
 
 
 def get_similarity(sol: str, sub: str) -> Tuple[float, float]:
     # Empty submission is 0% similar
-    if not sub.strip():
+    if is_empty_document(sub):
         return 0, 0
 
     from html_similarity import style_similarity, structural_similarity
@@ -34,7 +35,7 @@ def compare(solution_str: str, submission_str: str, trans: Translator, **kwargs)
 
     the submission html should be valid html
     """
-    if not submission_str.strip():
+    if is_empty_document(submission_str):
         raise NotTheSame(trans=trans, msg=trans.translate(Translator.Text.EMPTY_SUBMISSION), line=-1, pos=-1)
 
     # structure is always checked


### PR DESCRIPTION
If `abort` is set to `True` (default), the HTML validation will now fail & the compare test won't run. When `abort` is `False`, show 
a similarity of `0%` instead of crashing.

Also, if the HTML code in the submission is invalid, the similarity percentage won't be displayed at all (right now the html_similarity parser just crashes the judge). I figured that defaulting to `0%` was a bad idea because a solution could be near-identical with a typo, and make the parser fail, at which point it would be misleading to say it's at `0%`.

Fixes #196 