### PR TITLE
Add check for minimal HTML template

### DIFF
--- a/docs/pages/default-suites.md
+++ b/docs/pages/default-suites.md
@@ -21,6 +21,7 @@ The `HtmlSuite` will automatically create a TestSuite called "HTML", and add a `
 | `check_recommended` | <a id="check-recommended-image"/> A boolean that indicates if the student should see warnings about missing recommended attributes.<br /><br /><img src="../media/warnings-dodona.png" alt="image: warnings on Dodona."> These warnings do **not** cause their submission to be marked incorrect, and are purely informational.<br /><br /> | | `True` |
 | `allow_warnings` | Boolean that indicates that the check should *not* be marked incorrect if any warnings arise. |  | `True` |
 | `abort` | Boolean that indicates that testing should abort (and all future checks should be marked incorrect) when validation fails. This is default `True`, because you usually don't want to keep evaluating an exercise if the code isn't valid. |  | `True` |
+| `check_minimal` | Boolean that indicates that the minimal HTML-code required for a valid document should be present. <pre lang="html"><code><html>test</html></code></pre> Shortcut to adding **8** checks manually. | | `False` |
 
 #### Example usage
 

--- a/docs/pages/default-suites.md
+++ b/docs/pages/default-suites.md
@@ -8,6 +8,7 @@ Remember that these are still `TestSuite`s, so you can still **add your own Chec
 
 - [`HtmlSuite`](#htmlsuite)
 - [`CssSuite`](#csssuite)
+- [`Minimal HTML Template`](#minimal-html-template)
 
 ## `HtmlSuite`
 
@@ -21,7 +22,7 @@ The `HtmlSuite` will automatically create a TestSuite called "HTML", and add a `
 | `check_recommended` | <a id="check-recommended-image"/> A boolean that indicates if the student should see warnings about missing recommended attributes.<br /><br /><img src="../media/warnings-dodona.png" alt="image: warnings on Dodona."> These warnings do **not** cause their submission to be marked incorrect, and are purely informational.<br /><br /> | | `True` |
 | `allow_warnings` | Boolean that indicates that the check should *not* be marked incorrect if any warnings arise. |  | `True` |
 | `abort` | Boolean that indicates that testing should abort (and all future checks should be marked incorrect) when validation fails. This is default `True`, because you usually don't want to keep evaluating an exercise if the code isn't valid. |  | `True` |
-| `check_minimal` | Boolean that indicates that the minimal HTML-code required for a valid document should be present. <pre lang="html"><code><html>test</html></code></pre> Shortcut to adding **8** checks manually. | | `False` |
+| `check_minimal` | Boolean that indicates that the [minimal HTML code](#minimal-html-template) required for a valid document should be present. Shortcut to adding 8 checks manually. | | `False` |
 
 #### Example usage
 
@@ -78,6 +79,7 @@ The `CssSuite` will automatically create a TestSuite called "CSS", and add `Chec
 | `check_recommended` | <a id="check-recommended-image"/> A boolean that indicates if the student should see warnings about missing recommended attributes.<br /><br /><img src="../media/warnings-dodona.png" alt="image: warnings on Dodona."> These warnings do **not** cause their submission to be marked incorrect, and are purely informational.<br /><br /> | | `True` |
 | `allow_warnings` | Boolean that indicates that the check should *not* be marked incorrect if any warnings arise. |  | `True` |
 | `abort` | Boolean that indicates that testing should abort (and all future checks should be marked incorrect) when validation fails. This is default `True`, because you usually don't want to keep evaluating an exercise if the code isn't valid. |  | `True` |
+| `check_minimal` | Boolean that indicates that the [minimal HTML code](#minimal-html-template) required for a valid document should be present. Shortcut to adding 8 checks manually. | | `False` |
 
 #### Example usage
 
@@ -126,4 +128,22 @@ def create_suites(content: str) -> List[TestSuite]:
 
     # Or even shorter in case you only want validation:
     # return [CssSuite(content, allow_warnings=False)]
+```
+
+## `Minimal HTML Template`
+
+Both the [`HtmlSuite`](#htmlsuite) and the [`CssSuite`](#csssuite) have a `check_minimal`-kwarg that checks if the code below is present in the submission:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <!--  Any non-empty title suffices  -->
+    <title>Document</title>
+</head>
+<body>
+    
+</body>
+</html>
 ```

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,4 @@
+from dodona.translator import Translator
 from utils.file_loaders import html_loader as _html_loader
 from os import path
 
@@ -22,12 +23,13 @@ class UnitTestSuite(TestSuite):
         :param file: The HTML file to run the test against. The file extension (.html) can be left out.
         """
         super().__init__(name="TEST", content=html_loader(file), **kwargs)
+        self.translator = Translator(Translator.Language.EN)
 
     def check(self, c: Check) -> bool:
         return c.callback(self._bs)
 
     def checklist_item(self, c: ChecklistItem) -> bool:
-        return c.evaluate(self._bs)
+        return c.evaluate(self._bs, self.translator)
 
     def item(self, *args: Checks) -> ChecklistItem:
         return ChecklistItem("TEST", *args)

--- a/validators/checks.py
+++ b/validators/checks.py
@@ -1080,8 +1080,6 @@ class BoilerplateTestSuite(TestSuite):
     def __init__(self, name: str,
                  content: str,
                  check_recommended: bool = True,
-                 _default_translations: Optional[Dict[str, List[str]]] = None,
-                 _default_checks: Optional[List[ChecklistItem]] = None,
                  check_minimal: bool = False):
         super().__init__(name, content, check_recommended)
         self.check_minimal = check_minimal
@@ -1188,7 +1186,7 @@ class CssSuite(BoilerplateTestSuite):
     """TestSuite that does HTML and CSS validation by default"""
     allow_warnings: bool
 
-    def __init__(self, content: str, check_recommended: bool = True, allow_warnings: bool = True, abort: bool = True, check_minimal: bool = True):
+    def __init__(self, content: str, check_recommended: bool = True, allow_warnings: bool = True, abort: bool = True, check_minimal: bool = False):
         super().__init__("CSS", content, check_recommended, check_minimal)
 
         # Only abort if necessary

--- a/validators/checks.py
+++ b/validators/checks.py
@@ -805,7 +805,6 @@ class VerboseChecklistItem(ChecklistItem):
     def _process_one(self, check: Check, bs: BeautifulSoup, language: str) -> bool:
         """Modify the processing function to show the checks inside of it"""
         res = check.callback(bs)
-        # print(res)
         # Check if message should be printed
         if self.only_when_status is None or res == self.only_when_status:
             message = self.messages[language][self._checks.index(check)]

--- a/validators/checks.pyi
+++ b/validators/checks.pyi
@@ -195,11 +195,11 @@ class ChecklistItem:
 
     def __post_init__(self): ...
 
-    def _process_one(self, check: Check, bs: BeautifulSoup, translator: Translator, language: str) -> bool:
+    def _process_one(self, check: Check, bs: BeautifulSoup, language: str) -> bool:
         """Process a single check inside of this item"""
         ...
 
-    def evaluate(self, bs: BeautifulSoup, translator: Translator) -> bool:
+    def evaluate(self, bs: BeautifulSoup, language: str) -> bool:
         """Evaluate all checks inside of this item"""
         ...
 
@@ -285,19 +285,19 @@ class BoilerplateTestSuite(TestSuite):
     _default_translations: Optional[Dict[str, List[str]]] = ...
     _default_checks: Optional[List[ChecklistItem]] = ...
 
-    def __init__(self, name: str, content: str, check_recommended: bool = True): ...
+    def __init__(self, name: str, content: str, check_recommended: bool = True, check_minimal: bool = False): ...
 
 
 class HtmlSuite(BoilerplateTestSuite):
     allow_warnings: bool
 
-    def __init__(self, content: str, check_recommended: bool = True, allow_warnings: bool = True, abort: bool = True, minimal_template: bool = False): ...
+    def __init__(self, content: str, check_recommended: bool = True, allow_warnings: bool = True, abort: bool = True, check_minimal: bool = False): ...
 
 
 class CssSuite(BoilerplateTestSuite):
     allow_warnings: bool
 
-    def __init__(self, content: str, check_recommended: bool = True, allow_warnings: bool = True, abort: bool = True): ...
+    def __init__(self, content: str, check_recommended: bool = True, allow_warnings: bool = True, abort: bool = True, check_minimal: bool = False): ...
 
 
 class _CompareSuite(HtmlSuite):

--- a/validators/checks.pyi
+++ b/validators/checks.pyi
@@ -189,12 +189,19 @@ class ElementContainer:
 class ChecklistItem:
     message: str
     _checks: List[Check] = ...
+    _is_verbose: bool = False
 
     def __init__(self, message: str, *checks: Checks): ...
 
     def __post_init__(self): ...
 
-    def evaluate(self, bs: BeautifulSoup) -> bool: ...
+    def _process_one(self, check: Check, bs: BeautifulSoup, translator: Translator, language: str) -> bool:
+        """Process a single check inside of this item"""
+        ...
+
+    def evaluate(self, bs: BeautifulSoup, translator: Translator) -> bool:
+        """Evaluate all checks inside of this item"""
+        ...
 
 
 class TestSuite:
@@ -284,7 +291,7 @@ class BoilerplateTestSuite(TestSuite):
 class HtmlSuite(BoilerplateTestSuite):
     allow_warnings: bool
 
-    def __init__(self, content: str, check_recommended: bool = True, allow_warnings: bool = True, abort: bool = True): ...
+    def __init__(self, content: str, check_recommended: bool = True, allow_warnings: bool = True, abort: bool = True, minimal_template: bool = False): ...
 
 
 class CssSuite(BoilerplateTestSuite):


### PR DESCRIPTION
This is a bit bigger than it should be because I made some other stuff that might come in handy if we ever have to do something similar in the future instead of just hardcoding this one specific case.

A `VerboseChecklistItem` will print the tests inside of it, either `always` - only the ones that `succeed` - or only the ones that `fail`.

Fixes #155 