### PR TITLE
Any order for shorthand components

### DIFF
--- a/docs/pages/element-class.md
+++ b/docs/pages/element-class.md
@@ -599,7 +599,7 @@ value of the styling exactly.
 #### Signature
 
 ```python
-def has_styling(self, prop: str, value: Optional[str] = None, important: Optional[bool] = None, allow_inheritance: bool = False) -> Check
+def has_styling(self, prop: str, value: Optional[str] = None, important: Optional[bool] = None, allow_inheritance: bool = False, any_order: bool = True) -> Check
 ```
 
 #### Parameters
@@ -610,6 +610,7 @@ def has_styling(self, prop: str, value: Optional[str] = None, important: Optiona
 | `value`     | A value to match the property against.                                                                    |           | `None`, which will make any value pass and only checks if the element has this style property.  |
 | `important` | A boolean indicating that this element should (or may not be) marked as important using **`!important`**. |           | `None`, which won't check this.                                                                 |
 | `allow_inheritance` | A boolean indicating that a parent element can also have this styling and pass it down onto the child instead.  | | `False`, which will require the element itself to have this property. |
+| `any_order` | A boolean indicating that the order of the components does not matter, useful for [`shorthand properties`](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties) defined using [`double bar syntax`](https://developer.mozilla.org/en-US/docs/Web/CSS/Value_definition_syntax#double_bar). | | `False` |
 
 #### Example usage
 
@@ -626,6 +627,10 @@ div_tag.has_styling("background-color", allow_inheritance=True)
 
 # Check that the div has a horizontal margin of exactly 3px marked as !important
 div_tag.has_styling("margin", "3px", important=True)
+
+# Check that the div has a border with components width=1em, style=solid, color=blue
+# Will match every permutation, eg. "solid 1em blue", "blue solid 1em", ...
+div_tag.has_styling("border", "1em solid blue", any_order=True)
 ```
 
 ### `has_color()`

--- a/tests/html_files/css_1.html
+++ b/tests/html_files/css_1.html
@@ -7,6 +7,7 @@
         div {
             color: rgb(255, 0, 0) !important;
             margin: 3px;
+            border: 1em solid blue;
         }
 
         p {

--- a/tests/test_validators/test_element.py
+++ b/tests/test_validators/test_element.py
@@ -271,7 +271,7 @@ class TestElement(unittest.TestCase):
         div = suite.element("div")
         span = suite.element('span')
         phantom = suite.element("video")  # does not exist
-        # p = suite.element("p")
+        p = suite.element("p")
 
         self.assertTrue(suite.check(div.has_color("color", "red")))
         self.assertTrue(suite.check(div.has_color("color", "rgb(255, 0, 0)")))
@@ -288,11 +288,10 @@ class TestElement(unittest.TestCase):
         self.assertTrue(suite.check(span.has_color("color", "gold", allow_inheritance=True)))
         self.assertFalse(suite.check(span.has_color("color", "blue")))
 
-        # TODO #106
-        # self.assertTrue(suite.check(p.has_color("color", "gold")))
-        # self.assertTrue(suite.check(p.has_color("color", "#FFD700FF")))
-        # self.assertTrue(suite.check(p.has_color("color", "rgb(255, 215, 0)")))
-        # self.assertTrue(suite.check(p.has_color("color", "rgba(255, 215, 0, 1)")))
+        self.assertTrue(suite.check(p.has_color("color", "gold")))
+        self.assertTrue(suite.check(p.has_color("color", "#FFD700FF")))
+        self.assertTrue(suite.check(p.has_color("color", "rgb(255, 215, 0)")))
+        self.assertTrue(suite.check(p.has_color("color", "rgba(255, 215, 0, 1)")))
 
     def test_has_styling(self):
         suite = UnitTestSuite("css_1")

--- a/tests/test_validators/test_element.py
+++ b/tests/test_validators/test_element.py
@@ -317,6 +317,13 @@ class TestElement(unittest.TestCase):
         self.assertFalse(suite.check(span.has_styling("align-content", allow_inheritance=True)))
         self.assertFalse(suite.check(phantom.has_styling("border")))
 
+        self.assertTrue(suite.check(div.has_styling("border", "1em solid blue")))
+        self.assertTrue(suite.check(div.has_styling("border", "1em solid blue", any_order=True)))
+        self.assertFalse(suite.check(div.has_styling("border", "solid 1em blue")))
+        self.assertTrue(suite.check(div.has_styling("border", "solid 1em blue", any_order=True)))
+        self.assertFalse(suite.check(div.has_styling("border", "blue solid 1em")))
+        self.assertTrue(suite.check(div.has_styling("border", "blue solid 1em", any_order=True)))
+
     def test_no_loose_text(self):
         suite = UnitTestSuite("loose_text")
         phantom = suite.element("video")  # does not exist

--- a/validators/checks.py
+++ b/validators/checks.py
@@ -546,13 +546,15 @@ class Element:
         return prop_value
 
     @css_check
-    def has_styling(self, prop: str, value: Optional[str] = None, important: Optional[bool] = None, allow_inheritance: bool = False) -> Check:
+    def has_styling(self, prop: str, value: Optional[str] = None, important: Optional[bool] = None, allow_inheritance: bool = False, any_order: bool = False) -> Check:
         """Check that this element has a CSS property
         :param prop:                the required CSS property to check
         :param value:               an optional value to add that must be checked against,
                                     in case nothing is supplied any value will pass
         :param important:           indicate that this must (or may not be) marked as important
         :param allow_inheritance:   allow a parent element to have this property and apply it onto the child
+        :param any_order:           indicate that the order of the properties doesn't matter (double bar syntax for
+                                    shorthand properties)
         """
 
         def _inner(_: BeautifulSoup) -> bool:
@@ -569,6 +571,13 @@ class Element:
             # Value doesn't matter
             if value is None:
                 return True
+
+            # Any order should be allowed, so just split the values on spaces
+            # and sort them alphabetically
+            if any_order:
+                prop_value_sorted = list(sorted(prop_value.value_str.split(" ")))
+                value_sorted = list(sorted(value.split(" ")))
+                return prop_value_sorted == value_sorted
 
             return prop_value.value_str == value
 

--- a/validators/checks.pyi
+++ b/validators/checks.pyi
@@ -127,7 +127,7 @@ class Element:
         """
         ...
 
-    def has_styling(self, prop: str, value: Optional[str] = ..., important: Optional[bool] = ..., allow_inheritance: bool = False) -> Check:
+    def has_styling(self, prop: str, value: Optional[str] = ..., important: Optional[bool] = ..., allow_inheritance: bool = False, any_order: bool = True) -> Check:
         """Check that this element is matched by a CSS selector to give it a particular styling. A value can be passed to match the value of the styling exactly."""
         ...
 


### PR DESCRIPTION
To keep it easy I just split the requested & found values on spaces, sorted alphabetically & compared the results.

fixes #163 