### PR TITLE
Flag absolute src paths again on Python 3.13

### DIFF
--- a/tests/test_validators/test_html_validator.py
+++ b/tests/test_validators/test_html_validator.py
@@ -152,6 +152,7 @@ class TestHtmlValidator(unittest.TestCase):
         self.validator.validate_content("<img src='http://example.com/x.png'>")
         self.validator.validate_content("<img src='https://example.com/x.png'>")
         self.validator.validate_content("<img src='www.example.com/x.png'>")
+        self.validator.validate_content(r"<img src='C:x\y.jpg'>")  # drive-relative, not absolute
         # incorrect: absolute paths, in POSIX and Windows spelling, must be flagged
         with self.assertRaises(AttributeValueError):
             self.validator.validate_content("<img src='/home/q/image.jpg'>")

--- a/tests/test_validators/test_html_validator.py
+++ b/tests/test_validators/test_html_validator.py
@@ -141,3 +141,27 @@ class TestHtmlValidator(unittest.TestCase):
         with self.assertRaises(AttributeValueError):
             self.validator.validate_content("<img src='/home/q/Downloads/image.jpg'>")
 
+    def test_absolute_src_paths(self):
+        # regression test for https://github.com/python/cpython/issues/44626:
+        # ntpath.isabs stopped treating a leading (back)slash as absolute in Python 3.13
+        self.setup(False, False, False)
+        # correct: relative paths and URLs must not be flagged
+        self.validator.validate_content("<img src='image.jpg'>")
+        self.validator.validate_content("<img src='media/image.jpg'>")
+        self.validator.validate_content("<img src='../img/x.png'>")
+        self.validator.validate_content("<img src='http://example.com/x.png'>")
+        self.validator.validate_content("<img src='https://example.com/x.png'>")
+        self.validator.validate_content("<img src='www.example.com/x.png'>")
+        # incorrect: absolute paths, in POSIX and Windows spelling, must be flagged
+        with self.assertRaises(AttributeValueError):
+            self.validator.validate_content("<img src='/home/q/image.jpg'>")
+        with self.assertRaises(AttributeValueError):
+            self.validator.validate_content("<img src='//server/share/x.jpg'>")
+        with self.assertRaises(AttributeValueError):
+            self.validator.validate_content(r"<img src='\\server\share\x.jpg'>")
+        with self.assertRaises(AttributeValueError):
+            self.validator.validate_content(r"<img src='\images\x.png'>")
+        with self.assertRaises(AttributeValueError):
+            self.validator.validate_content(r"<img src='C:\x\y.jpg'>")
+        with self.assertRaises(AttributeValueError):
+            self.validator.validate_content("<img src='C:/x/y.jpg'>")

--- a/validators/html_validator.py
+++ b/validators/html_validator.py
@@ -20,6 +20,15 @@ PERMITTED_PARENTS_KEY = "permitted_parents"
 VOID_KEY = "void_tag"
 
 
+def _is_absolute_path(link: str) -> bool:
+    """Check whether a link is an absolute filepath, in POSIX or Windows spelling.
+
+    Python 3.13 made ntpath.isabs stop treating a leading (back)slash as absolute, so
+    it no longer catches "/home/student/image.png" on its own.
+    """
+    return link.startswith(("/", "\\")) or ntpath.isabs(link)
+
+
 class HtmlValidator(HTMLParser):
     """
     parses & validates the html
@@ -185,7 +194,7 @@ class HtmlValidator(HTMLParser):
         # check src attribute for absolute filepaths
         if 'src' in attributes:
             link = attributes['src']
-            if ntpath.isabs(link):
+            if _is_absolute_path(link):
                 self.error(AttributeValueError(trans=self.translator, msg=self.translator.translate(Translator.Text.NO_ABS_PATHS),
                                     line=self.getpos()[0], pos=self.getpos()[1]))
 

--- a/validators/html_validator.py
+++ b/validators/html_validator.py
@@ -1,5 +1,5 @@
-import ntpath
 from html.parser import HTMLParser
+from pathlib import PureWindowsPath
 from typing import Dict
 
 from dodona.translator import Translator
@@ -23,10 +23,15 @@ VOID_KEY = "void_tag"
 def _is_absolute_path(link: str) -> bool:
     """Check whether a link is an absolute filepath, in POSIX or Windows spelling.
 
-    Python 3.13 made ntpath.isabs stop treating a leading (back)slash as absolute, so
-    it no longer catches "/home/student/image.png" on its own.
+    A "rooted" path is exactly what we want to reject here: PureWindowsPath(...).root
+    is non-empty for both POSIX ("/home/student/image.png") and Windows
+    ("\\server\\share\\x.jpg", "C:\\x\\y.jpg") spellings, but empty for a drive-relative
+    path like "C:x\\y.jpg". Unlike ntpath.isabs, this meaning did not change in Python
+    3.13 (see https://github.com/python/cpython/issues/44626). We check .root rather
+    than .is_absolute(), because the latter wants a drive letter under Windows
+    semantics and would miss "/home/student/image.png" entirely.
     """
-    return link.startswith(("/", "\\")) or ntpath.isabs(link)
+    return bool(PureWindowsPath(link).root)
 
 
 class HtmlValidator(HTMLParser):


### PR DESCRIPTION
This PR fixes a regression caused by upgrading to Python 3.13 in the absolute-path checker helper. [`isabs` no longer treats a path starting with 1 slash as absolute](https://github.com/python/cpython/issues/44626):

```
Python 3.9:  ntpath.isabs("/home/q/image.jpg") -> True
Python 3.13: ntpath.isabs("/home/q/image.jpg") -> False
```

I couldn't find a proper replacement built in for it in ntpath, [issues have been open since 2007](https://github.com/python/cpython/issues/44626), so used a pathlib helper here instead. Claude first wrote something manually, which I was not a fan of.

Note that CI will only start to run as of #255 due to outdated actions, which is up next 😄 This just makes sure we can flip the pipeline green in one go without having these unrelated commits in there.

<details>
The judge flags `src` attributes that point at an absolute filepath, so students get
told to use a relative path instead. That check has been dead on the production image:
it used `ntpath.isabs`, and Python 3.13 [no longer treats a path starting with exactly
one slash as absolute](https://github.com/python/cpython/issues/44626).

`ghcr.io/dodona-edu/dodona-html:latest` ships Python 3.13.2, so `<img src="/home/student/image.png">`
just passed silently. CI didn't notice because it only runs Python 3.9, which is not
what the judge actually runs in. Found while setting up a CI job that runs the suite on
the real image.

The fix is `bool(PureWindowsPath(link).root)`. A non-empty `root` is exactly the set of
paths the old `ntpath.isabs` rejected: it covers both spellings (`/home/student/image.png`,
`\server\share\x.jpg`, `C:\x\y.jpg`) and is empty for a drive-relative `C:x\y.jpg`. Unlike
`isabs`, its meaning didn't change in 3.13. I checked the new expression against the old
one over all 13 cases on both 3.9 and 3.13: no disagreements.

Worth knowing, since it's the obvious thing to "simplify" this into later: `.is_absolute()`
is **not** the same test. It wants a drive letter under Windows semantics, so it returns
`False` for `/home/student/image.png` on 3.9 *and* on 3.13. Reaching for it would have left
the bug in place on every version. Hence `.root`, with a comment on the helper saying so.

`utils/render_ready.py` also imports from `ntpath` (`basename`), but that one is
deliberate (it has to cope with Windows paths in student submissions) and is still
correct on 3.13, so I left it alone.

</details>

## Testing

The existing suite plus the new `test_absolute_src_paths`, on both Pythons:

```sh
# the production image (Python 3.13.2)
docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w --user root \
  ghcr.io/dodona-edu/dodona-html:latest python -m unittest discover

# what CI runs today (Python 3.9)
docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w python:3.9-slim \
  sh -c "pip install -q -r requirements.txt && python -m unittest discover"
```

<details>
Both report `Ran 85 tests` / `OK (skipped=11)`. Before the fix, the 3.13 run fails on
`<img src='/home/q/Downloads/image.jpg'>`.

The red X on this PR is not from this change: the `Python` workflow has been failing on
`main` since July 2025, because GitHub auto-fails any workflow still on `actions/cache@v2`.
A follow-up PR replaces that workflow with one that runs on the real image.
</details>