### PR TITLE
Collapse all whitespace in compare_content, not just the first 8 runs

### DIFF
--- a/tests/test_validators/test_compare_content.py
+++ b/tests/test_validators/test_compare_content.py
@@ -10,3 +10,14 @@ class TestCompareContent(unittest.TestCase):
         self.assertTrue(compare_content(" test       ", " \t\n test \n\t\t\n      "))
         self.assertTrue(compare_content(" test  with  \t\t  \n    whitespace  \n\t\t         in between          \n",
                                         "test with whitespace in between"))
+
+    def test_cc_many_whitespace_runs(self):
+        # More than 8 internal whitespace runs, to catch a regression where only the
+        # first 8 runs of whitespace were being collapsed
+        self.assertTrue(compare_content("a  b\tc \n d   e\t\tf \n\n g  h\ti  j\t k",
+                                        "a b c d e f g h i j k"))
+
+    def test_cc_many_whitespace_runs_case_insensitive(self):
+        self.assertTrue(compare_content("A  B\tC \n D   E\t\tF \n\n G  H\tI  J\t K",
+                                        "a b c d e f g h i j k",
+                                        case_insensitive=True))

--- a/utils/html_navigation.py
+++ b/utils/html_navigation.py
@@ -165,8 +165,8 @@ def compare_content(first: str, second: str, case_insensitive: bool = False) -> 
     element_text = first.strip()
     arg_text = second.strip()
 
-    element_text = re.sub(r"\s+", " ", element_text, re.MULTILINE)
-    arg_text = re.sub(r"\s+", " ", arg_text, re.MULTILINE)
+    element_text = re.sub(r"\s+", " ", element_text)
+    arg_text = re.sub(r"\s+", " ", arg_text)
 
     if case_insensitive:
         element_text = element_text.lower()


### PR DESCRIPTION
This PR fixes `compare_content`: `compare_content` promises "equal, ignoring all whitespace", but it only ignored the first 8 runs of it since the 4th argument `re.sub` is "count", not "flags",. and `re.MULTILINE` is 8 😄 

```python
element_text = re.sub(r"\s+", " ", element_text, re.MULTILINE)
```

<details>
`re.sub`'s fourth positional parameter is `count`, not `flags`, and `re.MULTILINE` is
the int `8`. So everything past the 8th whitespace run kept its original spacing, and
two strings that differ only in that trailing whitespace compared as unequal. Anything
longer than a short sentence hits this, so checks like `.has_content()` on a paragraph
could reject a correct submission.

`re.MULTILINE` was pointless here anyway (it only changes what `^` and `$` match, and
this pattern has neither), so I dropped the argument instead of moving it to `flags=`.
Python 3.13 also warns about it: `DeprecationWarning: 'count' is passed as positional
argument`, which is how I noticed.

</details>

The existing `test_cc` didn't catch it because its longest case has 4 internal
whitespace runs, comfortably under the cut-off. Added two tests with 10.

Note that this will not cause the CI to pass since it has more issues. This is a fix to make it pass in a later PR (#255).

## Testing

```sh
docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w --user root \
  ghcr.io/dodona-edu/dodona-html:latest \
  python -m unittest tests.test_validators.test_compare_content
```

Green after, and both new tests fail with `AssertionError: False is not true` if you put
`re.MULTILINE` back.

<details>
<summary>Note on the full suite and on CI</summary>

Running the whole suite on the production image from this branch still shows one failure,
`test_html_validator.test_values`. That is an unrelated Python 3.13 bug, fixed separately
in #253.

CI is red here for neither reason: the `Python` workflow has been failing on `main` since
July 2025 because GitHub auto-fails any workflow still on `actions/cache@v2`. A follow-up
PR replaces it.
</details>
