### PR TITLE
Switch the test runner to pytest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,0 @@
-[run]
-omit =
-    tests/*
-    docs/*
-    .github/*

--- a/devel/run-tests.sh
+++ b/devel/run-tests.sh
@@ -5,5 +5,9 @@ ROOT="$(dirname "$(dirname "$0")")"
 
 cd "$ROOT"
 
-coverage run -m unittest discover
-coverage xml
+pytest -n auto \
+    --cov \
+    --cov-branch \
+    --cov-report xml \
+    --cov-report html \
+    "tests/" "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.coverage.run]
+omit = [
+    ".github/*",
+    "docs/*",
+    "htmlcov/*",
+    "*/site-packages/*",
+    "tests/*",
+    "venv/*",
+]
+source = ["."]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,6 @@
-coverage==7.1.0
+# pytest-cov pulls coverage in transitively, but the version it resolves to decides the
+# numbers codecov compares against, so pin it rather than letting it float.
+coverage==7.15.4
+pytest==9.1.1
+pytest-cov==7.1.0
+pytest-xdist==3.8.0


### PR DESCRIPTION
This PR switches the test runner to pytest.

<details>
`coverage run -m unittest discover` becomes `pytest -n auto --cov`, same as judge-sql.
The tests stay `unittest.TestCase` classes, pytest runs those as they are, so nothing
under `tests/` changes.

What it buys us: `-n auto` spreads the suite over the runner's cores, and pytest-cov
replaces the hand-rolled `coverage run` + `coverage xml` pair. The coverage config moves
from `.coveragerc` into `pyproject.toml`, which is where the ruff config wants to live in
the follow-ups anyway.

`coverage` itself is pinned explicitly rather than left to whatever pytest-cov
resolves, since that version decides the numbers codecov compares against.
</details>

## Testing

```sh
docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w --user root \
  ghcr.io/dodona-edu/dodona-html:latest \
  sh -c "./devel/install_test_deps.sh && ./devel/run-tests.sh"
```

`76 passed, 11 skipped`, which is the same 87 the old `unittest discover` reported
(unittest counts skips inside "Ran 87 tests", pytest splits them out). Ran it three times
with `-n auto` and once with `-n 0`: identical counts every time, so the parallelism isn't
hiding shared state between the tests.

The 11 skips are the pre-existing `@unittest.skip("TODO")` on the emmet test class.

