### PR TITLE
Lint with ruff's E, W, F and I rules

### DIFF
--- a/decorators/__init__.py
+++ b/decorators/__init__.py
@@ -1,2 +1,4 @@
-from .check_wrappers import html_check, css_check
+from .check_wrappers import css_check, html_check
 from .flatten import flatten_varargs
+
+__all__ = ["css_check", "html_check", "flatten_varargs"]

--- a/decorators/flatten.py
+++ b/decorators/flatten.py
@@ -1,4 +1,5 @@
 from inspect import getfullargspec
+
 from utils.flatten import flatten_queue
 
 

--- a/devel/check.sh
+++ b/devel/check.sh
@@ -5,4 +5,5 @@ ROOT="$(dirname "$(dirname "$0")")"
 
 cd "$ROOT"
 
+ruff check .
 ruff format --check .

--- a/docs/evaluator.py
+++ b/docs/evaluator.py
@@ -1,4 +1,5 @@
 from typing import List
+
 from validators import checks
 
 

--- a/dodona/dodona_command.py
+++ b/dodona/dodona_command.py
@@ -5,7 +5,7 @@ import sys
 from abc import ABC
 from enum import Enum
 from types import SimpleNamespace, TracebackType
-from typing import Union, Dict, Type, Optional
+from typing import Dict, Optional, Type, Union
 
 
 class ErrorType(str, Enum):

--- a/dodona/dodona_command.pyi
+++ b/dodona/dodona_command.pyi
@@ -1,7 +1,7 @@
 from abc import ABC
 from enum import Enum
 from types import SimpleNamespace, TracebackType
-from typing import Dict, Optional, Union, Type
+from typing import Dict, Optional, Type, Union
 
 class ErrorType(str, Enum):
     INTERNAL_ERROR = ...

--- a/evaluate_first_css_exercise.py
+++ b/evaluate_first_css_exercise.py
@@ -1,4 +1,5 @@
 from typing import List
+
 from validators import checks
 
 

--- a/evaluate_first_html_exercise.py
+++ b/evaluate_first_html_exercise.py
@@ -1,4 +1,5 @@
 from typing import List
+
 from validators import checks
 
 

--- a/exceptions/utils.py
+++ b/exceptions/utils.py
@@ -72,5 +72,4 @@ class DelayedExceptions(Exception):
         self.exceptions.clear()
 
     def _print_exceptions(self) -> str:
-        x: FeedbackException
         return "\n".join([x.message_str() for x in self.exceptions])

--- a/html_judge.py
+++ b/html_judge.py
@@ -2,22 +2,22 @@ import os
 import sys
 from typing import List, Optional
 
-from dodona.dodona_command import Judgement, Message, ErrorType, Tab, MessageFormat
+from dodona.dodona_command import ErrorType, Judgement, Message, MessageFormat, Tab
 from dodona.dodona_config import DodonaConfig
 from dodona.translator import Translator
 from exceptions.utils import InvalidTranslation
 from utils.evaluation_module import EvaluationModule
 from utils.file_loaders import html_loader
-from validators import checks
-from validators.checks import TestSuite
-from utils.render_ready import prep_render
 from utils.messages import (
-    invalid_suites,
     invalid_evaluator_file,
+    invalid_suites,
     missing_create_suite,
     missing_evaluator_file,
     no_suites_found,
 )
+from utils.render_ready import prep_render
+from validators import checks
+from validators.checks import TestSuite
 
 
 def main():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,18 @@ source = ["."]
 line-length = 120
 # Keep in step with .tool-versions; ruff defaults to py310 and can't infer it without a [project] table.
 target-version = "py313"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I"]
+ignore = [
+    # The validators do `from ... import *`, which makes every name they pull in look
+    # undefined. Untangling those is its own change, see the follow-up PR.
+    "F403",
+    "F405",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Feedback strings stay on one line so they stay greppable and diff cleanly.
+"dodona/translator.py" = ["E501"]
+# Stub signatures and their one-line docstrings don't wrap usefully.
+"*.pyi" = ["E501"]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,9 +1,10 @@
-from dodona.translator import Translator
-from utils.file_loaders import html_loader as _html_loader
 from os import path
 
+from dodona.translator import Translator
+from utils.file_loaders import html_loader as _html_loader
+
 # Location of this test file
-from validators.checks import TestSuite, Check, ChecklistItem, Checks
+from validators.checks import Check, ChecklistItem, Checks, TestSuite
 
 basepath = path.dirname(__file__)
 

--- a/tests/test_utils/test_color_converter.py
+++ b/tests/test_utils/test_color_converter.py
@@ -1,4 +1,5 @@
 import unittest
+
 from utils.color_converter import Color
 
 

--- a/tests/test_utils/test_emmet.py
+++ b/tests/test_utils/test_emmet.py
@@ -1,8 +1,8 @@
+import unittest
+
 from bs4 import BeautifulSoup
 
 from utils.emmet import emmet_to_check
-import unittest
-
 from validators.checks import TestSuite
 
 
@@ -41,11 +41,11 @@ class TestEmmet(unittest.TestCase):
         doc = """
             <body>
                 <table>
-                    <tr></tr> 
+                    <tr></tr>
                     <tr>
                         <td>test</td>
                         <td>text</td>
-                    </tr>                   
+                    </tr>
                 </table>
             </body>
         """
@@ -200,7 +200,7 @@ class TestEmmet(unittest.TestCase):
                     <tr>
                         <td>test</td>
                     </tr>
-                    <tr></tr>                            
+                    <tr></tr>
                 </table>
             </body>
         """

--- a/tests/test_utils/test_flatten.py
+++ b/tests/test_utils/test_flatten.py
@@ -1,6 +1,7 @@
 import unittest
-from validators.checks import ChecklistItem, all_of, any_of
+
 from tests.helpers import UnitTestSuite
+from validators.checks import ChecklistItem, all_of, any_of
 
 
 class TestFlatten(unittest.TestCase):

--- a/tests/test_utils/test_html_checks.py
+++ b/tests/test_utils/test_html_checks.py
@@ -1,4 +1,5 @@
 import unittest
+
 from utils import html_checks
 
 

--- a/tests/test_utils/test_regexes.py
+++ b/tests/test_utils/test_regexes.py
@@ -1,6 +1,7 @@
-from utils import regexes
-import unittest
 import re
+import unittest
+
+from utils import regexes
 
 
 class TestRegexes(unittest.TestCase):
@@ -14,7 +15,7 @@ class TestRegexes(unittest.TestCase):
         self.assertIsNotNone(regex.search("<!DOCTYPE HTML>\n<html..."))
         self.assertIsNotNone(
             regex.search("""
-        <!-- 
+        <!--
             multiline comment
         --><!--another comment with an > inside of it -->
         <!--comment--><!doctype html><html></html>

--- a/tests/test_validators/test_compare_content.py
+++ b/tests/test_validators/test_compare_content.py
@@ -1,5 +1,6 @@
-from utils.html_navigation import compare_content
 import unittest
+
+from utils.html_navigation import compare_content
 
 
 class TestCompareContent(unittest.TestCase):

--- a/tests/test_validators/test_css_validator.py
+++ b/tests/test_validators/test_css_validator.py
@@ -1,8 +1,9 @@
 import unittest
+
 from bs4 import BeautifulSoup
 
 from utils.color_converter import Color
-from validators.css_validator import CssValidator, Rule, Rules
+from validators.css_validator import CssValidator
 
 html = """<!DOCTYPE html>
 <html lang="en">
@@ -100,7 +101,8 @@ html = """<!DOCTYPE html>
 
 <div class="test_element_with_attribute_endswith_value" test_element_with_attribute_endswith_value="aavalue"></div>
 
-<div class="test_element_with_attribute_contains_substring_value" test_element_with_attribute_contains_substring_value="aavalueaa"></div>
+<div class="test_element_with_attribute_contains_substring_value"
+     test_element_with_attribute_contains_substring_value="aavalueaa"></div>
 
 <div class="test_most_precise"></div>
 

--- a/tests/test_validators/test_double_char_validator.py
+++ b/tests/test_validators/test_double_char_validator.py
@@ -2,8 +2,8 @@ import unittest
 from typing import List
 
 from dodona.translator import Translator
-from validators.double_chars_validator import DoubleCharsValidator
 from exceptions.double_char_exceptions import MultipleMissingCharsError
+from validators.double_chars_validator import DoubleCharsValidator
 
 
 class TestDoubleCharValidator(unittest.TestCase):
@@ -124,7 +124,7 @@ class TestDoubleCharValidator(unittest.TestCase):
             <!--
             function displayMsg) {
               alert"Hello World!")
-            
+
             //-->
             """,
                 """<body><h1>Check if brackets/quotes open and close (`(`, '&lt;', `{`, `[`, `'`, `"`)<h1></body>""",

--- a/tests/test_validators/test_element.py
+++ b/tests/test_validators/test_element.py
@@ -1,5 +1,6 @@
 import re
 import unittest
+
 from tests.helpers import UnitTestSuite
 from validators.checks import all_of, any_of, at_least, fail_if
 

--- a/tests/test_validators/test_element_container.py
+++ b/tests/test_validators/test_element_container.py
@@ -1,6 +1,7 @@
-from tests.helpers import UnitTestSuite
-from validators.checks import Element, EmptyElement, ElementContainer
 import unittest
+
+from tests.helpers import UnitTestSuite
+from validators.checks import Element, ElementContainer, EmptyElement
 
 
 class TestElementContainer(unittest.TestCase):

--- a/tests/test_validators/test_emmet_methods.py
+++ b/tests/test_validators/test_emmet_methods.py
@@ -1,5 +1,6 @@
-from tests.helpers import UnitTestSuite
 import unittest
+
+from tests.helpers import UnitTestSuite
 
 
 class TestEmmetMethods(unittest.TestCase):

--- a/tests/test_validators/test_html_validator.py
+++ b/tests/test_validators/test_html_validator.py
@@ -1,8 +1,8 @@
 import unittest
 
 from dodona.translator import Translator
-from validators.html_validator import HtmlValidator
 from exceptions.html_exceptions import *
+from validators.html_validator import HtmlValidator
 
 
 class TestHtmlValidator(unittest.TestCase):

--- a/tests/test_validators/test_structure_validator.py
+++ b/tests/test_validators/test_structure_validator.py
@@ -1,7 +1,7 @@
 import unittest
 
 from dodona.translator import Translator
-from validators.structure_validator import compare, NotTheSame
+from validators.structure_validator import NotTheSame, compare
 
 
 class TestHtmlValidator(unittest.TestCase):

--- a/tests/test_validators/test_testsuite.py
+++ b/tests/test_validators/test_testsuite.py
@@ -1,7 +1,8 @@
 import re
 import unittest
-from tests.helpers import html_loader, UnitTestSuite
-from validators.checks import TestSuite, ChecklistItem
+
+from tests.helpers import UnitTestSuite, html_loader
+from validators.checks import ChecklistItem, TestSuite
 
 
 class TestTestSuite(unittest.TestCase):

--- a/utils/color_converter.py
+++ b/utils/color_converter.py
@@ -52,7 +52,7 @@ class Color(Col):
             super(Color, self).__init__(val)
 
     def __eq__(self, other):
-        if other is None or type(other) != type(self):
+        if other is None or type(other) is not type(self):
             return False
         if self.alpha != other.alpha:
             return False

--- a/utils/emmet.py
+++ b/utils/emmet.py
@@ -1,6 +1,6 @@
-from emmet import parse_markup_abbreviation, AbbreviationAttribute, AbbreviationNode
+from emmet import AbbreviationAttribute, AbbreviationNode, parse_markup_abbreviation
 
-from validators.checks import TestSuite, Element, all_of, EmptyElement, Check
+from validators.checks import Check, Element, EmptyElement, TestSuite, all_of
 
 
 def emmet_to_check(emmet_str: str, suite: TestSuite) -> Check:

--- a/utils/flatten.py
+++ b/utils/flatten.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, List, Iterable
+
+from typing import TYPE_CHECKING, Iterable, List
 
 if TYPE_CHECKING:
-    from validators.checks import Checks, Check
+    from validators.checks import Check, Checks
 
 
 def flatten_queue(*queue: Checks) -> List["Check"]:

--- a/utils/html_navigation.py
+++ b/utils/html_navigation.py
@@ -1,7 +1,8 @@
 import re
-from typing import Optional, Union, List
+from typing import List, Optional, Union
+
 from bs4 import BeautifulSoup
-from bs4.element import Tag, Comment
+from bs4.element import Comment, Tag
 
 
 def match_emmet(tag: Optional[str]) -> bool:

--- a/utils/messages.py
+++ b/utils/messages.py
@@ -1,9 +1,9 @@
+import traceback
 from types import SimpleNamespace
 
-from dodona.dodona_command import Message, MessageFormat, ErrorType, MessagePermission
+from dodona.dodona_command import ErrorType, Message, MessageFormat, MessagePermission
 from dodona.dodona_config import DodonaConfig
 from dodona.translator import Translator
-import traceback
 
 
 def invalid_suites(judge: SimpleNamespace, config: DodonaConfig):

--- a/utils/regexes.py
+++ b/utils/regexes.py
@@ -1,6 +1,5 @@
-from collections import namedtuple
 import re
-
+from collections import namedtuple
 
 Regex = namedtuple("Regex", "pattern flags")
 

--- a/utils/render_ready.py
+++ b/utils/render_ready.py
@@ -1,7 +1,9 @@
+from ntpath import basename
+
 import bs4
 from bs4.element import Tag
-from ntpath import basename
-from validators.css_validator import Rules, Rule
+
+from validators.css_validator import Rule, Rules
 
 
 def prep_render(html_content: str, render_css: bool) -> (str, str):

--- a/utils/render_ready.py
+++ b/utils/render_ready.py
@@ -6,7 +6,7 @@ from bs4.element import Tag
 from validators.css_validator import Rule, Rules
 
 
-def prep_render(html_content: str, render_css: bool) -> (str, str):
+def prep_render(html_content: str, render_css: bool) -> tuple[str, str]:
     """prepares the html for rendering:
     a body and a style tag must be present, if not returns the input html
     if both are present:

--- a/validators/checks.py
+++ b/validators/checks.py
@@ -4,23 +4,23 @@ import re
 from collections import deque
 from copy import copy
 from dataclasses import dataclass, field
-from typing import Deque, List, Optional, Callable, Union, Dict, TypeVar, Iterable, Iterator
+from typing import Callable, Deque, Dict, Iterable, Iterator, List, Optional, TypeVar, Union
 from urllib.parse import urlsplit
 
 from bs4 import BeautifulSoup
-from bs4.element import Tag, NavigableString
+from bs4.element import NavigableString, Tag
 
-from decorators import flatten_varargs, html_check, css_check
-from dodona.dodona_command import Context, TestCase, Message, MessageFormat, SafeAnnotation
+from decorators import css_check, flatten_varargs, html_check
+from dodona.dodona_command import Context, Message, MessageFormat, SafeAnnotation, TestCase
 from dodona.dodona_config import DodonaConfig
 from dodona.translator import Translator
-from exceptions.double_char_exceptions import MultipleMissingCharsError, LocatableDoubleCharError
-from exceptions.html_exceptions import Warnings, LocatableHtmlValidationError
+from exceptions.double_char_exceptions import LocatableDoubleCharError, MultipleMissingCharsError
+from exceptions.html_exceptions import LocatableHtmlValidationError, Warnings
 from exceptions.utils import EvaluationAborted
 from utils.flatten import flatten_queue
-from utils.html_navigation import find_child, compare_content, match_emmet, find_emmet, contains_comment
+from utils.html_navigation import compare_content, contains_comment, find_child, find_emmet, match_emmet
 from utils.regexes import doctype_re
-from validators.css_validator import CssValidator, CssParsingError, Rule, AmbiguousXpath, ElementNotFound
+from validators.css_validator import AmbiguousXpath, CssParsingError, CssValidator, ElementNotFound, Rule
 from validators.html_validator import HtmlValidator
 
 # Custom type hints
@@ -607,7 +607,8 @@ class Element:
         :param value:               an optional value to add that must be checked against,
                                     in case nothing is supplied any value will pass
         :param important:           indicate that this must (or may not be) marked as important
-        :param pseudo:              the css selector pseudo class to check the property for (example "hover", or "clicked")
+        :param pseudo:              the css selector pseudo class to check the property for (example "hover", or
+                                    "clicked")
         :param allow_inheritance:   allow a parent element to have this property and apply it onto the child
         :param any_order:           indicate that the order of the properties doesn't matter (double bar syntax for
                                     shorthand properties)
@@ -1011,8 +1012,8 @@ class TestSuite:
         """Compare the submission to the solution html."""
 
         def _inner(_: BeautifulSoup):
-            from validators.structure_validator import compare, get_similarity
             from exceptions.structure_exceptions import NotTheSame
+            from validators.structure_validator import compare, get_similarity
 
             try:
                 compare(solution, self.content, translator, **kwargs)

--- a/validators/checks.pyi
+++ b/validators/checks.pyi
@@ -1,8 +1,8 @@
 from re import RegexFlag
+from typing import Callable, Dict, Iterable, Iterator, List, Optional, TypeVar, Union
 
 from bs4 import BeautifulSoup
 from bs4.element import Tag
-from typing import Callable, List, Optional, Union, Dict, TypeVar, Iterable, Iterator
 
 from dodona.dodona_config import DodonaConfig
 from dodona.translator import Translator

--- a/validators/css_validator.py
+++ b/validators/css_validator.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Tuple, Dict
+from typing import Dict, List, Optional, Tuple
 
 import tinycss2
 import tinycss2.nth
@@ -28,13 +28,15 @@ Specificity for single selectors from highest to lowest:
     ids (example: #main selects <div id="main">)
     classes (ex.: .myclass), attribute selectors (ex.: [href=^https:]) and pseudo-classes (ex.: :hover)
     elements (ex.: div) and pseudo-elements (ex.: ::before)
-    To compare the specificity of two combined selectors, compare the number of occurences of single selectors of each of the specificity groups above.
+    To compare the specificity of two combined selectors, compare the number of occurences of single selectors of
+    each of the specificity groups above.
 
 Example: compare #nav ul li a:hover to #nav ul li.active a::after
 
 count the number of id selectors: there is one for each (#nav)
 count the number of class selectors: there is one for each (:hover and .active)
-count the number of element selectors: there are 3 (ul li a) for the first and 4 for the second (ul li a ::after), thus the second combined selector is more specific.
+count the number of element selectors: there are 3 (ul li a) for the first and 4 for the second (ul li a ::after),
+thus the second combined selector is more specific.
 
 USAGE:
 >>> validator = CssValidator(html_content)

--- a/validators/css_validator.py
+++ b/validators/css_validator.py
@@ -28,7 +28,7 @@ Specificity for single selectors from highest to lowest:
     ids (example: #main selects <div id="main">)
     classes (ex.: .myclass), attribute selectors (ex.: [href=^https:]) and pseudo-classes (ex.: :hover)
     elements (ex.: div) and pseudo-elements (ex.: ::before)
-    To compare the specificity of two combined selectors, compare the number of occurences of single selectors of
+    To compare the specificity of two combined selectors, compare the number of occurrences of single selectors of
     each of the specificity groups above.
 
 Example: compare #nav ul li a:hover to #nav ul li.active a::after

--- a/validators/css_validator.pyi
+++ b/validators/css_validator.pyi
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from bs4.element import Tag
 from lxml.etree import ElementBase

--- a/validators/double_chars_validator.py
+++ b/validators/double_chars_validator.py
@@ -1,7 +1,7 @@
 import copy
 
-from exceptions.double_char_exceptions import *
 from dodona.translator import Translator
+from exceptions.double_char_exceptions import *
 
 
 class DoubleChar:

--- a/validators/double_chars_validator.pyi
+++ b/validators/double_chars_validator.pyi
@@ -1,8 +1,7 @@
-from typing import Tuple, List
+from typing import List, Tuple
 
-from exceptions.double_char_exceptions import *
-from exceptions.double_char_exceptions import *
 from dodona.translator import Translator
+from exceptions.double_char_exceptions import *
 
 class DoubleChar:
     type: str

--- a/validators/html_validator.py
+++ b/validators/html_validator.py
@@ -1,14 +1,13 @@
+from functools import lru_cache
 from html.parser import HTMLParser
+from os import path
 from pathlib import PureWindowsPath
 from typing import Dict
 
 from dodona.translator import Translator
 from exceptions.html_exceptions import *
-from os import path
-
-from utils.file_loaders import json_loader, html_loader
+from utils.file_loaders import html_loader, json_loader
 from validators.double_chars_validator import DoubleCharsValidator
-from functools import lru_cache
 
 # Location of this test file
 base_path = path.dirname(__file__)

--- a/validators/html_validator.pyi
+++ b/validators/html_validator.pyi
@@ -1,8 +1,8 @@
 from html.parser import HTMLParser
-from typing import List, Dict, Tuple, Set
+from typing import Dict, List, Set, Tuple
 
 from dodona.translator import Translator
-from exceptions.html_exceptions import Warnings, HtmlValidationError, MissingRecommendedAttributesWarning
+from exceptions.html_exceptions import HtmlValidationError, MissingRecommendedAttributesWarning, Warnings
 from validators.double_chars_validator import DoubleCharsValidator
 
 class HtmlValidator(HTMLParser):

--- a/validators/structure_validator.py
+++ b/validators/structure_validator.py
@@ -1,12 +1,12 @@
-from dodona.translator import Translator
-from lxml.html import fromstring, HtmlElement, HtmlComment
-
-from exceptions.structure_exceptions import NotTheSame
-from validators.css_validator import CssValidator
-from utils.html_navigation import compare_content
-from utils.html_checks import is_empty_document
-
 from typing import Tuple
+
+from lxml.html import HtmlComment, HtmlElement, fromstring
+
+from dodona.translator import Translator
+from exceptions.structure_exceptions import NotTheSame
+from utils.html_checks import is_empty_document
+from utils.html_navigation import compare_content
+from validators.css_validator import CssValidator
 
 
 def get_similarity(sol: str, sub: str) -> Tuple[float, float]:
@@ -14,7 +14,7 @@ def get_similarity(sol: str, sub: str) -> Tuple[float, float]:
     if is_empty_document(sub):
         return 0, 0
 
-    from html_similarity import style_similarity, structural_similarity
+    from html_similarity import structural_similarity, style_similarity
 
     a = sol.find("<style")
     b = sub.find("<style")
@@ -28,10 +28,14 @@ def compare(solution_str: str, submission_str: str, trans: Translator, **kwargs)
     """compare submission structure to the solution structure (html)
     possible kwargs:
     * attributes: (default: False) check whether attributes are exactly the same in solution and submission
-    * minimal_attributes: (default: False) check whether at least the attributes in solution are supplied in the submission
-    * contents: (default: False) check whether the contents of each tag in the solution are exactly the same as in the submission
-    * css: (default: True) if there are css rules defined in the solution, check if the submission can match these rules.
-            We don't compare the css rules itself, but rather whether every element in the submission has at least the css-rules defined in the solution.
+    * minimal_attributes: (default: False) check whether at least the attributes in solution are supplied in the
+            submission
+    * contents: (default: False) check whether the contents of each tag in the solution are exactly the same as
+            in the submission
+    * css: (default: True) if there are css rules defined in the solution, check if the submission can match
+            these rules.
+            We don't compare the css rules itself, but rather whether every element in the submission has at least
+            the css-rules defined in the solution.
     Raises a NotTheSame exception if the solution and the submission are not alike
 
     the submission html should be valid html


### PR DESCRIPTION
This PR follows up #257 by actually enabling some linting rules after formatting with Ruff. No linter has every worked here, so we're starting slow by enabling error, warning, flakes and imports. We can widen this in future PRs.

<details>
The parent PR put ruff in place and ran the formatter. This one turns on actual lint
rules: `E`, `W`, `F`, `I`, and adds `ruff check .` to `devel/check.sh`.

I kept the rule set small on purpose. judge-sql is heading towards `select = ["ALL"]` with
an ignore list (dodona-edu/judge-sql#222), but judge-html has never been linted at all, and
`ALL` here reports a few thousand findings. Better to get a floor in place that CI can
hold, and widen it in later PRs than to make this one unreviewable.

Two things parked rather than fixed:

- `F403`/`F405` (62 findings) are ignored for now. Five modules do
  `from exceptions.html_exceptions import *` and friends, which makes every name they
  pull in look undefined. That is its own change, see the follow-up.
- `E501` is per-file-ignored for `dodona/translator.py` and for `*.pyi`. The translator's
  long lines are single feedback strings, and wrapping them would only make them harder
  to grep for and noisier to diff. The `.pyi` ones are stub signatures with a one-line
  docstring, which don't wrap into anything nicer.

That leaves 61 findings, of which 43 were auto-fixable (nearly all import sorting) and 18
needed a decision:

- `decorators/__init__.py` is a re-export module, so it got an explicit `__all__` rather
  than having its "unused" imports deleted.
- `utils/color_converter.py` compared types with `!=` inside `__eq__` (E721), now `is not`.
- `exceptions/utils.py` had a stray `x: FeedbackException` annotation sitting on its own
  line above a comprehension that binds its own `x`. It did nothing, so it's gone.
- Five bits of trailing whitespace inside triple-quoted HTML fixtures in the tests. I
  checked whether any of it was load-bearing before stripping it, none of it was.
- Eight long lines wrapped. Seven are comments or docstrings. The eighth is an HTML
  fixture string in `test_css_validator.py`: the wrap sits between two attributes inside a
  tag, where any run of whitespace is one separator to the parser, so the parsed DOM comes
  out the same. Shout if you'd rather that one stayed long.

Ruff also dropped a duplicated `from exceptions.double_char_exceptions import *` line in
`validators/double_chars_validator.pyi`, which was there twice in a row.

Two more fixes came out of review, each in its own commit. Neither is a ruff finding,
not even under `select = ["ALL"]`:

- `prep_render`'s return annotation was `(str, str)`, which is a tuple *value* rather
  than the type `tuple[str, str]`. Nothing broke over it, since annotations aren't
  evaluated, but ty does flag it (`invalid-type-form`), so it would have surfaced
  anyway once `utils/` joins the type-checked scope.
- A docstring in `css_validator.py` said "occurences".
</details>

## Testing

```sh
./devel/check.sh

docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w --user root \
  ghcr.io/dodona-edu/dodona-html:latest \
  sh -c "./devel/install_test_deps.sh && ./devel/run-tests.sh"
```

`All checks passed!` from ruff, and still `74 passed, 11 skipped` from the suite.

