### PR TITLE
Replace the star imports with explicit ones

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,6 @@ target-version = "py313"
 
 [tool.ruff.lint]
 select = ["E", "W", "F", "I"]
-ignore = [
-    # The validators do `from ... import *`, which makes every name they pull in look
-    # undefined. Untangling those is its own change, see the follow-up PR.
-    "F403",
-    "F405",
-]
 
 [tool.ruff.lint.per-file-ignores]
 # Feedback strings stay on one line so they stay greppable and diff cleanly.

--- a/tests/test_validators/test_html_validator.py
+++ b/tests/test_validators/test_html_validator.py
@@ -1,7 +1,18 @@
 import unittest
 
 from dodona.translator import Translator
-from exceptions.html_exceptions import *
+from exceptions.html_exceptions import (
+    AttributeValueError,
+    DuplicateIdError,
+    InvalidAttributeError,
+    InvalidTagError,
+    MissingClosingTagError,
+    MissingRequiredAttributesError,
+    NoSelfClosingTagError,
+    UnexpectedClosingTagError,
+    UnexpectedTagError,
+    Warnings,
+)
 from validators.html_validator import HtmlValidator
 
 

--- a/validators/css_validator.py
+++ b/validators/css_validator.py
@@ -6,7 +6,14 @@ from bs4.element import Tag
 from cssselect import GenericTranslator, SelectorError
 from lxml.etree import ElementBase
 from lxml.html import fromstring
-from tinycss2.ast import *
+from tinycss2.ast import (
+    Declaration,
+    LiteralToken,
+    Node,
+    ParseError,
+    QualifiedRule,
+    WhitespaceToken,
+)
 
 from utils.color_converter import Color
 

--- a/validators/double_chars_validator.py
+++ b/validators/double_chars_validator.py
@@ -1,7 +1,11 @@
 import copy
 
 from dodona.translator import Translator
-from exceptions.double_char_exceptions import *
+from exceptions.double_char_exceptions import (
+    MissingClosingCharError,
+    MissingOpeningCharError,
+    MultipleMissingCharsError,
+)
 
 
 class DoubleChar:

--- a/validators/double_chars_validator.pyi
+++ b/validators/double_chars_validator.pyi
@@ -1,7 +1,6 @@
 from typing import List, Tuple
 
 from dodona.translator import Translator
-from exceptions.double_char_exceptions import *
 
 class DoubleChar:
     type: str

--- a/validators/html_validator.py
+++ b/validators/html_validator.py
@@ -5,7 +5,21 @@ from pathlib import PureWindowsPath
 from typing import Dict
 
 from dodona.translator import Translator
-from exceptions.html_exceptions import *
+from exceptions.html_exceptions import (
+    AttributeValueError,
+    DuplicateIdError,
+    HtmlValidationError,
+    InvalidAttributeError,
+    InvalidTagError,
+    MissingClosingTagError,
+    MissingOpeningTagError,
+    MissingRecommendedAttributesWarning,
+    MissingRequiredAttributesError,
+    NoSelfClosingTagError,
+    UnexpectedClosingTagError,
+    UnexpectedTagError,
+    Warnings,
+)
 from utils.file_loaders import html_loader, json_loader
 from validators.double_chars_validator import DoubleCharsValidator
 


### PR DESCRIPTION
This PR works on some more ruff rules (#258) by fixing the star imports with explicit ones.

<details>
The previous PR had to park `F403`/`F405` because five modules pull their names in with
`from ... import *`, which makes 62 perfectly ordinary references look undefined. This
replaces those with explicit imports and drops the two entries from the ignore list.

Five files, and the lists turned out smaller than I expected:

- `validators/html_validator.py` and `tests/.../test_html_validator.py` pull 13 and 10
  names from `exceptions.html_exceptions`.
- `validators/double_chars_validator.py` pulls 3 from `exceptions.double_char_exceptions`.
- `validators/css_validator.py` stars in `tinycss2.ast`, which is third-party, and uses
  exactly 6 of it: `Declaration, LiteralToken, Node, ParseError, QualifiedRule,
  WhitespaceToken`. Small enough that the explicit list reads fine.
- `validators/double_chars_validator.pyi` had a star import that nothing in the stub used
  at all, so that one is just deleted. Checked that nothing imports those names *through*
  the stub either: only `DoubleCharsValidator` is imported from that module elsewhere, and
  the stub still declares it.

Also double-checked the other direction, that no name got dropped by accident: for each
file, every class defined in the starred module that is *not* in the new import list was
grepped for and doesn't appear.

Nothing here is only about the linter: an explicit import list is what tells you where a
name comes from without having to go and read the other module, and it is what lets an
editor jump to the definition.

Stacked on the ruff lint PR.
</details>

## Testing

```sh
./devel/check.sh

docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w --user root \
  ghcr.io/dodona-edu/dodona-html:latest \
  sh -c "./devel/install_test_deps.sh && ./devel/run-tests.sh"
```

`All checks passed!` with F403/F405 now active, and still `74 passed, 11 skipped`.
