### PR TITLE
Let dependabot update the GitHub Actions too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: pip
     directory: "/"
     schedule:
-      interval: weekly
-      day: monday
+      interval: monthly
       time: "04:00"
       timezone: Europe/Brussels
     open-pull-requests-limit: 99

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,27 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Europe/Brussels
+    open-pull-requests-limit: 99
+    labels:
+      - dependencies
+    groups:
+      pytest:
+        patterns:
+          - "pytest*"
+      linters:
+        patterns:
+          - "ruff"
+          - "ty"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Europe/Brussels
+    open-pull-requests-limit: 99
+    labels:
+      - dependencies


### PR DESCRIPTION
This PR lets dependabot update the GitHub actions too.

<details>

Dependabot only watched pip here, so the GitHub Actions we pin were never updated by
anything. That is how the old workflow ended up sitting on `actions/cache@v2` until GitHub
started auto-failing it, which took CI on `main` down in July 2025 without anyone
noticing. Adding the `github-actions` ecosystem means the next deprecation arrives as a PR
instead of as a red `main`.

Same config as judge-sql (dodona-edu/judge-sql#204), so the two judges stay consistent:

- `github-actions` ecosystem alongside `pip`
- a fixed time, 04:00 Europe/Brussels, instead of "weekly, whenever": `github-actions`
  weekly on Monday, `pip` monthly
- the `dependencies` label, so the PRs are filterable
- `open-pull-requests-limit: 99`, since the default of 5 quietly hides updates
- groups for `pytest*` and for `ruff`/`ty`, so a linter bump is one PR instead of three

`pip` running monthly is a deliberate difference from judge-sql, which does it weekly.
We review python dependencies in batches rather than as they land, so weekly only
builds a backlog. `github-actions` stays weekly, since that's the one that goes stale
in a way that breaks CI.

Those two groups don't match anything yet. They start doing something as the sibling PRs
land: pytest in #256, ruff in #257 and #258, ty in #260. Grouping patterns that match
nothing are a no-op for Dependabot, so there's no harm in them waiting.

Stacked on #255, which is what adds `requirements-test.txt` and the two workflows this
config now has to cover.

## Testing

Not much to run here. The file parses as YAML, and GitHub validates it on push: Insights >
Dependency graph > Dependabot shows a parse error if it doesn't like it. Worth a look
there once this is in.
</details>
