### PR TITLE
Stop codecov from commenting on every pull request

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,9 +1,6 @@
-comment:
-  layout: "reach, diff, flags, files"
-  behavior: default
-  require_changes: false  # if true: only post the comment if coverage changes
-  require_base: no        # [yes :: must have a base report to post]
-  require_head: yes       # [yes :: must have a head report to post]
+# No comment on the pull request: the numbers still show up as checks, and a bot
+# comment on every PR is just noise.
+comment: false
 
 coverage:
   round: down


### PR DESCRIPTION
This PR stops codecov from commenting on every pull request.

<details>
Codecov posts a comment on every PR. The same numbers are already in the checks panel,
so the comment is noise on top of information we've got.

`comment: false` turns the comment off and leaves the `codecov/project` and
`codecov/patch` statuses alone, since those are configured separately under `coverage`.
The `layout` / `behavior` / `require_*` keys that were there only shaped the comment, so
they go with it.

Worth knowing: `comment: true` is not valid in their schema, so `false` is the only
boolean that belongs on that key.

Takes effect once this is on `main`, since that's the config Codecov reads for a PR.
</details>

## Testing

Nothing to run. The file parses as YAML and the top-level `comment` key is the boolean
`false`:

```sh
python3 -c "import yaml;d=yaml.safe_load(open('codecov.yaml'));print(repr(d['comment']), list(d))"
# False ['comment', 'coverage', 'ignore']
```
