### PR TITLE
Un-skip the Emmet tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ In a lot of cases you're going to want the students to write _something_ or to g
 
 2. Create an `evaluator.py` file in the `evaluation` folder with the following code:
 
-    > `evaluator.py` (Python 3.9+ **required**)
+    > `evaluator.py`
     >
     > ```python
     > from validators.checks import HtmlSuite, CssSuite, TestSuite, ChecklistItem

--- a/docs/pages/evaluators.md
+++ b/docs/pages/evaluators.md
@@ -14,7 +14,7 @@ All evaluators should follow a strict interface: the file should always be calle
 
 The fragment below contains the [boilerplate](https://en.wikipedia.org/wiki/Boilerplate_code) to make an evaluator:
 
-> `evaluator.py` (Python 3.9+ recommended)
+> `evaluator.py`
 >
 > ```python
 > from typing import List

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,9 @@ select = ["E", "W", "F", "I"]
 "dodona/translator.py" = ["E501"]
 # Stub signatures and their one-line docstrings don't wrap usefully.
 "*.pyi" = ["E501"]
+
+[tool.pytest.ini_options]
+# All test classes are unittest.TestCase subclasses, which pytest always collects
+# regardless of python_classes. Narrow the pattern so it stops matching bare "Test*"
+# names like validators/checks.py's TestSuite dataclass (which isn't a test).
+python_classes = []

--- a/tests/test_utils/test_emmet.py
+++ b/tests/test_utils/test_emmet.py
@@ -10,7 +10,6 @@ def do(emmet, document) -> bool:
     return emmet_to_check(emmet, TestSuite("My test suite", document)).callback(BeautifulSoup(document, "html.parser"))
 
 
-@unittest.skip("TODO")
 class TestEmmet(unittest.TestCase):
     def test_child(self):
         doc = """
@@ -25,6 +24,8 @@ class TestEmmet(unittest.TestCase):
         self.assertFalse(do("div>ul>li>li", doc))
         self.assertFalse(do("div>ol>li", doc))
 
+    # Indexed selectors like tr[1]/td[1] aren't matched yet (#269)
+    @unittest.expectedFailure
     def test_index(self):
         doc = """
             <ul>
@@ -65,6 +66,8 @@ class TestEmmet(unittest.TestCase):
         self.assertTrue(do("div+blockquote+p", doc))
         self.assertFalse(do("div+img+p", doc))
 
+    # The ^^ climb-up operator matches a structure it shouldn't (#269)
+    @unittest.expectedFailure
     def test_climb_up(self):
         doc = """
             <div></div>
@@ -139,6 +142,8 @@ class TestEmmet(unittest.TestCase):
         """
         self.assertTrue(do("(div>dl>(dt+dd)*3)+footer>p", doc))
 
+    # A bare class selector .header matches when it shouldn't (#269)
+    @unittest.expectedFailure
     def test_id_and_class(self):
         doc = """
             <body>
@@ -207,6 +212,8 @@ class TestEmmet(unittest.TestCase):
         self.assertTrue(do("body>table>tr*2", doc))
         self.assertFalse(do("body>table>tr*3", doc))
 
+    # DUMMY should require non-empty text and doesn't (#269)
+    @unittest.expectedFailure
     def test_dummy(self):
         doc = """
         <html lang='en'>

--- a/tests/test_utils/test_emmet.py
+++ b/tests/test_utils/test_emmet.py
@@ -24,7 +24,7 @@ class TestEmmet(unittest.TestCase):
         self.assertFalse(do("div>ul>li>li", doc))
         self.assertFalse(do("div>ol>li", doc))
 
-    # Indexed selectors like tr[1]/td[1] aren't matched yet (#269)
+    # Indexed selectors like tr[1]/td[1] aren't matched yet (#170)
     @unittest.expectedFailure
     def test_index(self):
         doc = """
@@ -66,7 +66,7 @@ class TestEmmet(unittest.TestCase):
         self.assertTrue(do("div+blockquote+p", doc))
         self.assertFalse(do("div+img+p", doc))
 
-    # The ^^ climb-up operator matches a structure it shouldn't (#269)
+    # The ^^ climb-up operator matches a structure it shouldn't (#170)
     @unittest.expectedFailure
     def test_climb_up(self):
         doc = """
@@ -142,7 +142,7 @@ class TestEmmet(unittest.TestCase):
         """
         self.assertTrue(do("(div>dl>(dt+dd)*3)+footer>p", doc))
 
-    # A bare class selector .header matches when it shouldn't (#269)
+    # A bare class selector .header matches when it shouldn't (#170)
     @unittest.expectedFailure
     def test_id_and_class(self):
         doc = """
@@ -212,7 +212,7 @@ class TestEmmet(unittest.TestCase):
         self.assertTrue(do("body>table>tr*2", doc))
         self.assertFalse(do("body>table>tr*3", doc))
 
-    # DUMMY should require non-empty text and doesn't (#269)
+    # DUMMY should require non-empty text and doesn't (#170)
     @unittest.expectedFailure
     def test_dummy(self):
         doc = """


### PR DESCRIPTION
This PR un-skips the Emmet tests that were mistakenly marked as skipped after adding `@unittest.skip` to get the CI to pass on the codecov action. We'll skip the ones that were failing before that line was added, to not loose coverage on working & tested code. The remaining tests will be picked up through #170.

<details>

The suite reported 11 skipped tests. All 11 were one `@unittest.skip("TODO")` sitting on the
whole `TestEmmet` class, so nobody had looked at what was underneath it in a while.

Seven of the eleven pass as they are. The other four each fail on a distinct Emmet feature
that was never implemented, and each already carried an inline `# TODO` on the exact
assertion. Those four are now `@unittest.expectedFailure` with a one-line comment naming the
gap, and the gaps are written up in #170, which has tracked exactly these failing tests
since 2021.

Worth knowing how they went quiet, because it wasn't a decision about Emmet: #169 merged
with these tests failing and #170 was filed the same day, then ten days later `aeeae18`
("Add codecov GH action", #183) added the one `@unittest.skip` line to get CI green for an
unrelated PR. That skipped the whole class, so the 7 tests that pass went dark along with
the 4 that don't.

That way the seven that work actually run, and the four that don't stay visible: if someone
implements one of these, its test flips to an unexpected success and CI fails, which is the
prompt to remove the marker. A skipped class gives you neither.

Worth knowing what the four are, since three of them are false positives, i.e. the Emmet
check reports a match where there is none. For a judge that direction is the more awkward
one, because it means a submission can be accepted for a structure it doesn't actually have.

Also in here: pytest was emitting `PytestCollectionWarning: cannot collect test class
'TestSuite'` on every run. That is the judge's own dataclass in `validators/checks.py`, which
pytest only probed because the name starts with `Test`. Every test class in this repo is a
`unittest.TestCase`, and those are collected through a separate code path that doesn't
consult `python_classes` at all, so setting it empty stops the probing without costing us
anything. The test count confirms that: 87 collected before and after.

</details>

## Testing

```sh
docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w --user root \
  ghcr.io/dodona-edu/dodona-html:latest \
  sh -c "./devel/install_test_deps.sh && ./devel/run-tests.sh"
```

`83 passed, 4 xfailed`, no skips, and the collection warning is gone. Before: `76 passed,
11 skipped`. Same 87 tests collected either way, so nothing was lost in the `python_classes`
change. `./devel/check.sh` still passes.

