### PR TITLE
Drop the stale Python 3.9 floor from the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ In a lot of cases you're going to want the students to write _something_ or to g
 
 2. Create an `evaluator.py` file in the `evaluation` folder with the following code:
 
-    > `evaluator.py` (Python 3.9+ **required**)
+    > `evaluator.py`
     >
     > ```python
     > from validators.checks import HtmlSuite, CssSuite, TestSuite, ChecklistItem

--- a/docs/pages/evaluators.md
+++ b/docs/pages/evaluators.md
@@ -14,7 +14,7 @@ All evaluators should follow a strict interface: the file should always be calle
 
 The fragment below contains the [boilerplate](https://en.wikipedia.org/wiki/Boilerplate_code) to make an evaluator:
 
-> `evaluator.py` (Python 3.9+ recommended)
+> `evaluator.py`
 >
 > ```python
 > from typing import List


### PR DESCRIPTION
This PR removes the stale 3.9 Python reference from the readme file. We're using constructs now that are above that, and tooling (.tool-version and pyproject) both mention 3.13 as working python version. The base image also runs on Python 3.13.

<details>

Both places we document `evaluator.py` tell teachers they need Python 3.9+:

- `README.md` — "`evaluator.py` (Python 3.9+ **required**)"
- `docs/pages/evaluators.md` — "`evaluator.py` (Python 3.9+ recommended)"

That's four minor versions stale, and it isn't harmless: a teacher reading it will avoid
`X | None`, `match`, and anything else newer, on the belief that their evaluator has to run
on 3.9. It doesn't. It runs on whatever the judge image ships, which is 3.13.2 today.

The history, since it explains what the line was ever for:

1. `079ad88` (2021-09-25) added it as "Python 3.9+ *recommended*", directly above a snippet
   annotating `-> list[TestSuite]`. That builtin generic is PEP 585, so it needs 3.9. The
   note existed to justify the syntax in the example.
2. `1ce1315` (2021-10-26), titled "Remove 3.8 workflow", changed the CI matrix from
   `python: [3.8, 3.9]` to `[3.9]` and strengthened *recommended* to **required** in the
   same two-line commit.

So it was always a statement about the judge's own runtime, tracked by hand against the CI
matrix, and it stopped being updated the moment the matrix moved on.

Rather than bump it to 3.13 and inherit the same problem, it goes. The version the judge runs
is already recorded in three places that can't drift: `.tool-versions`, the pins in
`requirements.txt` that mirror the image, and ruff's `target-version` in `pyproject.toml`.

The filename label stays, which is what the surrounding docs do anyway. README line 251
already uses a bare `> \`evaluator.py\``.

<details>
<summary>Related, not fixed here</summary>

The snippet in `docs/pages/evaluators.md` still opens with `from typing import List`. Ruff's
`UP` rules don't reach code blocks in Markdown, so it survived the modernisation in the
follow-up PR. Worth a tidy at some point.
</details>

</details> 
## Testing

Docs only, nothing to run. The suite and linters are untouched.
