### PR TITLE
Close the html_loader wrapper tags

### DIFF
--- a/tests/test_utils/test_file_loaders.py
+++ b/tests/test_utils/test_file_loaders.py
@@ -1,0 +1,88 @@
+import tempfile
+import unittest
+from os import path
+
+from bs4 import BeautifulSoup
+
+from utils.file_loaders import html_loader
+
+
+class TestFileLoaders(unittest.TestCase):
+    CONTENT = "<p>Some content</p>"
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.file_path = path.join(self.tmpdir.name, "fragment.html")
+        with open(self.file_path, "w") as f:
+            f.write(self.CONTENT)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_no_wrap_by_default(self):
+        """Without any wrap_* kwarg, the content should be returned unchanged"""
+        result = html_loader(self.file_path)
+        self.assertEqual(result, self.CONTENT)
+
+    def test_wrap_head(self):
+        result = html_loader(self.file_path, wrap_head=True)
+
+        # Properly closed, not doubled open
+        self.assertIn("</head>", result)
+        self.assertEqual(result.count("<head"), 1)
+
+        soup = BeautifulSoup(result, "html.parser")
+        head = soup.find("head")
+        self.assertIsNotNone(head)
+        self.assertIn(self.CONTENT, str(head))
+
+    def test_wrap_body(self):
+        result = html_loader(self.file_path, wrap_body=True)
+
+        self.assertIn("</body>", result)
+        self.assertEqual(result.count("<body"), 1)
+
+        soup = BeautifulSoup(result, "html.parser")
+        body = soup.find("body")
+        self.assertIsNotNone(body)
+        self.assertIn(self.CONTENT, str(body))
+
+    def test_wrap_html(self):
+        result = html_loader(self.file_path, wrap_html=True)
+
+        self.assertIn("</html>", result)
+        self.assertEqual(result.count("<html"), 1)
+
+        soup = BeautifulSoup(result, "html.parser")
+        html = soup.find("html")
+        self.assertIsNotNone(html)
+        self.assertIn(self.CONTENT, str(html))
+
+    def test_wrap_all(self):
+        """wrap_head, wrap_body and wrap_html combined should each close properly"""
+        result = html_loader(self.file_path, wrap_head=True, wrap_body=True, wrap_html=True)
+
+        self.assertIn("</head>", result)
+        self.assertIn("</body>", result)
+        self.assertIn("</html>", result)
+        self.assertEqual(result.count("<head"), 1)
+        self.assertEqual(result.count("<body"), 1)
+        self.assertEqual(result.count("<html"), 1)
+
+        soup = BeautifulSoup(result, "html.parser")
+        html = soup.find("html")
+        body = soup.find("body")
+        head = soup.find("head")
+        self.assertIsNotNone(html)
+        self.assertIsNotNone(body)
+        self.assertIsNotNone(head)
+
+        # wrap_head is applied first, then wrap_body, then wrap_html, so the
+        # nesting order (per the current implementation) is html > body > head
+        self.assertIn(self.CONTENT, str(head))
+        self.assertIn(str(head), str(body))
+        self.assertIn(str(body), str(html))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/file_loaders.py
+++ b/utils/file_loaders.py
@@ -20,13 +20,13 @@ def html_loader(file_path: str, **kwargs) -> str:
         content = file.read()
 
         if kwargs.get("wrap_head", False):
-            content = f"<head>{content}<head>"
+            content = f"<head>{content}</head>"
 
         if kwargs.get("wrap_body", False):
-            content = f"<body>{content}<body>"
+            content = f"<body>{content}</body>"
 
         if kwargs.get("wrap_html", False):
-            content = f"<html lang='en'>{content}<html>"
+            content = f"<html lang='en'>{content}</html>"
 
         return content
 


### PR DESCRIPTION
This PR fixes a bug that didn't close the `html_loader` wrapper tags, but just added another opening tag at the end.

<details>
`html_loader`'s three `wrap_*` options each append a second *opening* tag where they mean to
close the first:

```python
content = f"<head>{content}<head>"              # should be </head>
content = f"<body>{content}<body>"              # should be </body>
content = f"<html lang='en'>{content}<html>"    # should be </html>
```

So every one of them produces invalid markup, which is the opposite of what the docstring
promises ("wraps the content in a `<head>` tag"). Copilot spotted it on #271 while reviewing
something unrelated.

It's dormant: nothing in the repo passes `wrap_head`, `wrap_body` or `wrap_html`, so no
caller reaches it today. That's presumably how it survived. Worth fixing anyway, since the
next person to reach for those kwargs would get silently broken HTML rather than an error,
and this is a judge that parses HTML for a living.

Also adds `tests/test_utils/test_file_loaders.py`, which didn't exist. Five tests: one per
wrapper, one for all three combined, and one for the default no-kwargs path. They assert on
structure through BeautifulSoup rather than on raw strings, plus a `count("<head") == 1`
check, which is the assertion that actually catches this particular shape of bug.

</details>

## Testing

Confirmed the tests fail before the fix, rather than assuming they would. Against the
unmodified code, 4 of the 5 fail:

```
AssertionError: '</head>' not found in '<head><p>Some content</p><head>'
AssertionError: '</body>' not found in '<body><p>Some content</p><body>'
AssertionError: '</html>' not found in "<html lang='en'><p>Some content</p><html>"
```

(`test_no_wrap_by_default` passes either way, as it should, since it never touches the buggy
paths.)

```sh
docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w --user root \
  ghcr.io/dodona-edu/dodona-html:latest \
  sh -c "./devel/install_test_deps.sh && ./devel/run-tests.sh"
```

`81 passed, 11 skipped`, which is the 76 on `main` plus these 5. `./devel/check.sh` passes.
