### PR TITLE
Add a CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: "21 14 * * 0"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ python ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
This PR replaces #234, the lgtm-migrator PR that's been sitting open since November 2022.

<details>
Nothing wrong with what it proposed, it's just pinned to `actions/checkout@v3` and `github/codeql-action@v2`. codeql-action v2 has been out of support for a while and GitHub fails those runs outright now, so merging #234 as-is would have added a workflow that goes red on its first scheduled run.

This is judge-sql's `codeql.yml` instead, on `checkout@v7` and `codeql-action@v4`, so the two repos stay the same shape. Same `queries: +security-and-quality`, same `permissions` block, same python-only matrix.

One deliberate difference from judge-sql: the cron stays on this repo's own slot (`21 14 * * 0`, from #234) rather than judge-sql's `47 23 * * 0`. No reason to have both repos kick off their weekly scan at the same moment, and that's presumably why the generator randomised it per repo in the first place.

</details>

## Testing

Not much to run locally: it's a workflow, and CodeQL only really tells you anything once it runs on the default branch. The YAML parses and resolves to a single `analyze` job. The action majors are current (`checkout` v7, `codeql-action` v4).

The scheduled trigger won't fire until this is on `main`, but the `pull_request` trigger means the run on this branch is the real check.

Closes #234.

