### PR TITLE
Type the html_check and css_check decorators

### DIFF
--- a/decorators/check_wrappers.py
+++ b/decorators/check_wrappers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Concatenate, Protocol, cast
 
@@ -47,6 +48,7 @@ def html_check[S: _HasElement, **P, R](
 ) -> Callable[Concatenate[S, P], R]:
     """Decorator that checks if an HTML element is not None"""
 
+    @functools.wraps(func)
     def wrapper(self: S, *args: P.args, **kwargs: P.kwargs) -> R:
         if self._element is None:
             return cast("R", fail())
@@ -61,6 +63,7 @@ def css_check[S: _HasCssValidator, **P, R](
 ) -> Callable[Concatenate[S, P], R]:
     """Decorator that checks if an element's HTML tag and CSS validator are not None"""
 
+    @functools.wraps(func)
     def wrapper(self: S, *args: P.args, **kwargs: P.kwargs) -> R:
         if self._element is None or self._css_validator is None:
             return cast("R", fail())

--- a/decorators/check_wrappers.py
+++ b/decorators/check_wrappers.py
@@ -1,6 +1,20 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Concatenate, Protocol, cast
+
 from bs4 import BeautifulSoup
 
+if TYPE_CHECKING:
+    from bs4.element import Tag
 
+    from validators.css_validator import CssValidator
+
+
+# Deliberately left without a `-> Check` return annotation. validators/checks.pyi sits next
+# to checks.py, so an annotation here resolves Check to the stub, and ty then reads that as a
+# different type from the class checks.py defines. checks.py returns fail() itself, and the
+# annotation would turn that into an error about two types with the same name.
 def fail():
     """Return a Check that always fails"""
     # Local import to avoid circular dependencies
@@ -12,25 +26,45 @@ def fail():
     return Check(_inner)
 
 
-def html_check(func):
+class _HasElement(Protocol):
+    """The part of Element that html_check needs to see
+
+    Spelled as a protocol instead of importing Element, because validators.checks
+    imports this module and the type would be a circular reference.
+    """
+
+    _element: Tag | None
+
+
+class _HasCssValidator(_HasElement, Protocol):
+    """The part of Element that css_check needs to see"""
+
+    _css_validator: CssValidator | None
+
+
+def html_check[S: _HasElement, **P, R](
+    func: Callable[Concatenate[S, P], R],
+) -> Callable[Concatenate[S, P], R]:
     """Decorator that checks if an HTML element is not None"""
 
-    def wrapper(*args, **kwargs):
-        if args[0]._element is None:
-            return fail()
+    def wrapper(self: S, *args: P.args, **kwargs: P.kwargs) -> R:
+        if self._element is None:
+            return cast("R", fail())
 
-        return func(*args, **kwargs)
+        return func(self, *args, **kwargs)
 
     return wrapper
 
 
-def css_check(func):
+def css_check[S: _HasCssValidator, **P, R](
+    func: Callable[Concatenate[S, P], R],
+) -> Callable[Concatenate[S, P], R]:
     """Decorator that checks if an element's HTML tag and CSS validator are not None"""
 
-    def wrapper(*args, **kwargs):
-        if args[0]._element is None or args[0]._css_validator is None:
-            return fail()
+    def wrapper(self: S, *args: P.args, **kwargs: P.kwargs) -> R:
+        if self._element is None or self._css_validator is None:
+            return cast("R", fail())
 
-        return func(*args, **kwargs)
+        return func(self, *args, **kwargs)
 
     return wrapper

--- a/decorators/flatten.py
+++ b/decorators/flatten.py
@@ -1,3 +1,4 @@
+import functools
 from inspect import getfullargspec
 
 from utils.flatten import flatten_queue
@@ -14,6 +15,7 @@ def flatten_varargs(func):
     if argspec.varargs is None:
         return func
 
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         args = list(args)
 

--- a/validators/checks.py
+++ b/validators/checks.py
@@ -231,21 +231,27 @@ class Element:
         False
         """
 
+        # @html_check already returned a failing Check if there was no element
+        element = cast("Tag", self._element)
+
         def _inner(_: BeautifulSoup) -> bool:
             # No text in this element
-            if self._element.text is None or len(self._element.text) == 0:
+            if element.text is None or len(element.text) == 0:
                 return False
 
             if text is not None:
-                return compare_content(self._element.text, text, case_insensitive)
+                return compare_content(element.text, text, case_insensitive)
 
-            return len(self._element.text.strip()) > 0
+            return len(element.text.strip()) > 0
 
         return Check(_inner)
 
     def _has_tag(self, tag: str) -> bool:
         """Internal function that checks if this element has the required tag"""
-        return self._element.name.lower() == tag.lower()
+        # Only reached from methods that @html_check has already guarded
+        element = cast("Tag", self._element)
+
+        return element.name.lower() == tag.lower()
 
     @html_check
     def has_tag(self, tag: str) -> Check:
@@ -260,8 +266,11 @@ class Element:
     def no_loose_text(self) -> Check:
         """Check that there is no content floating around in this tag"""
 
+        # @html_check already returned a failing Check if there was no element
+        element = cast("Tag", self._element)
+
         def _inner(_: BeautifulSoup) -> bool:
-            children = self._element.children
+            children = element.children
 
             for child in children:
                 # Child is a text instance which is not allowed
@@ -276,7 +285,10 @@ class Element:
 
     def _get_attribute(self, attr: str) -> list[str] | str | None:
         """Internal function that gets an attribute"""
-        attribute = self._element.get(attr.lower())
+        # Only reached from methods that @html_check has already guarded
+        element = cast("Tag", self._element)
+
+        attribute = element.get(attr.lower())
 
         return attribute
 
@@ -396,13 +408,16 @@ class Element:
     def has_table_header(self, header: list[str]) -> Check:
         """If this element is a table, check that the header content matches up"""
 
+        # @html_check already returned a failing Check if there was no element
+        element = cast("Tag", self._element)
+
         def _inner(_: BeautifulSoup) -> bool:
             # This element is not a table
             if not self._has_tag("table"):
                 return False
 
             # List of all headers in this table
-            ths = self._element.find_all("th")
+            ths = element.find_all("th")
 
             # Not the same amount of headers
             if len(ths) != len(header):
@@ -428,12 +443,15 @@ class Element:
         :param case_insensitive:    Indicate that comparison should ignore casing or not
         """
 
+        # @html_check already returned a failing Check if there was no element
+        element = cast("Tag", self._element)
+
         def _inner(_: BeautifulSoup) -> bool:
             # This element is not a table
             if not self._has_tag("table"):
                 return False
 
-            trs = self._element.find_all("tr")
+            trs = element.find_all("tr")
 
             # No rows found
             if not trs:
@@ -473,12 +491,15 @@ class Element:
     def table_row_has_content(self, row: list[str], case_insensitive: bool = False) -> Check:
         """Check the content of one row instead of the whole table"""
 
+        # @html_check already returned a failing Check if there was no element
+        element = cast("Tag", self._element)
+
         def _inner(_: BeautifulSoup) -> bool:
             # Check that this element is a <tr>
             if not self._has_tag("tr"):
                 return False
 
-            tds = self._element.find_all("td")
+            tds = element.find_all("td")
 
             # Amount of items doesn't match up
             if len(tds) != len(row):
@@ -568,17 +589,22 @@ class Element:
         """
         prop = prop.lower()
 
+        # Only reached from methods that @css_check has already guarded, so neither
+        # the element nor the validator can be None here
+        element = cast("Tag", self._element)
+        css_validator = cast("CssValidator", self._css_validator)
+
         # Inheritance is not allowed
         if not inherit:
-            return self._css_validator.find(self._element, prop, pseudo)
+            return css_validator.find(element, prop, pseudo)
 
-        current_element = self._element
+        current_element = element
         prop_value = None
 
         # Keep going higher up the tree until a match is found
         while prop_value is None and current_element is not None:
             # Check if the current element has this rule & applies it onto the child
-            prop_value = self._css_validator.find(current_element, prop, pseudo)
+            prop_value = css_validator.find(current_element, prop, pseudo)
 
             if prop_value is None:
                 parents = current_element.find_parents()
@@ -1070,8 +1096,12 @@ class TestSuite:
         if self._css_validator is None:
             return fail()
 
+        # Bind it here: the narrowing above doesn't reach into the closure, and
+        # _css_validator is only ever set in __post_init__
+        css_validator = self._css_validator
+
         def _inner(_: BeautifulSoup) -> bool:
-            rule: Rule = self._css_validator.find_by_css_selector(css_selector, prop)
+            rule = css_validator.find_by_css_selector(css_selector, prop)
             # If the property is not found, it is None
             return False if rule is None else rule.compare_to(value, important, any_order)
 


### PR DESCRIPTION
`html_check` and `css_check` were `def wrapper(*args, **kwargs)` reaching into `args[0]`, so they erased the signature of every method they decorate. Written with `ParamSpec` and `Concatenate` they keep it, and `self` stops being an untyped positional.

<details>
That fixes the signature, but not the reason ty flagged 15 lines *inside* those methods. Both decorators return early when `self._element` (and, for `css_check`, `self._css_validator`) is `None`, so by the time the body runs the field is provably set. No decorator can tell a type checker that about a field it doesn't own, so each body now narrows once, up front, right next to the decorator that guarantees it, and the closure closes over the narrowed local instead of re-reading the optional field. Neither field is ever reassigned after construction, so this reads exactly what it read before.

`TestSuite.contains_css` needed no `cast` at all: it already guards on `_css_validator is None` itself, and binding the result to a local before the closure is enough for the guard to carry into it. Its `rule: Rule` annotation was wrong too, `find_by_css_selector` returns `Rule | None` and the very next line tests for `None`.

<details>
<summary>Why a Protocol for <code>self</code>, and why <code>fail()</code> stays unannotated</summary>

`validators.checks` imports this module, so annotating the decorators with `Element` would be a circular reference. A two-member Protocol (`_element`, and `_css_validator` for `css_check`) says exactly what the wrappers touch, and ty checks structurally that `Element` satisfies it.

`fail()` deliberately keeps no `-> Check` annotation, with a comment saying so. `validators/checks.pyi` sits next to `checks.py`, so an annotation here resolves `Check` to the stub, and ty reads that as a different type from the class `checks.py` defines. `checks.py` returns `fail()` itself in `contains_css`, so the annotation would turn that line into an error about two types with the same name. The same reason is why the wrappers return `R` (with the `fail()` path cast) rather than `R | Check`: that union leaked the stub's `Check` into three more call sites in `checks.py`.

Three private helpers (`_has_tag`, `_get_attribute`, `_find_css_property`) are only ever reached through a decorated method, so they narrow the same way, with a comment saying where the guarantee comes from.

</details>
</details>

## Testing

```sh
docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w python:3.13-slim \
  sh -c "./devel/install_deps.sh && ./devel/install_dev_deps.sh && ./devel/check.sh"

docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w --user root \
  ghcr.io/dodona-edu/dodona-html:latest \
  sh -c "./devel/install_test_deps.sh && ./devel/run-tests.sh"
```

`./devel/check.sh` passes, and the tests are `91 passed, 4 xfailed`, unchanged.

ty over `validators/ utils/` goes **65 to 50**.

## Left alone

No public API changes, and `validators/checks.pyi` isn't touched at all. Two sites in this area stay flagged because they're bs4 `PageElement`-vs-`Tag` problems rather than narrowing problems (`_find_css_property` walking `find_parents()`, and `has_url_with_fragment`); those belong with the third-party gaps.
