### PR TITLE
Treat an empty style tag as having no CSS

### DIFF
--- a/tests/test_validators/test_css_validator.py
+++ b/tests/test_validators/test_css_validator.py
@@ -120,6 +120,20 @@ html = """<!DOCTYPE html>
 
 
 class TestCssValidator(unittest.TestCase):
+    def test_empty_style_tag(self):
+        """An empty <style></style> has no CSS, which is not the same as being unparseable"""
+        # style.text is None here, which used to reach Rules() and raise a TypeError that
+        # TestSuite.__post_init__ doesn't catch, so the whole judge run fell over
+        validator = CssValidator("<html><head><style></style></head><body><p>x</p></body></html>")
+        self.assertEqual(validator.rules.rules, [])
+        self.assertFalse(validator)
+
+    def test_missing_style_tag(self):
+        """A document with no <style> at all behaves the same way"""
+        validator = CssValidator("<html><head></head><body><p>x</p></body></html>")
+        self.assertEqual(validator.rules.rules, [])
+        self.assertFalse(validator)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.bs: BeautifulSoup = BeautifulSoup(html, "html.parser")

--- a/validators/css_validator.py
+++ b/validators/css_validator.py
@@ -322,10 +322,8 @@ class CssValidator:
             # that follows is what the except below is there to swallow
             style = cast("_Element", self.root.find(".//style"))
 
-            # An empty <style></style> gives text None, and Rules() then raises a TypeError
-            # that TestSuite.__post_init__ doesn't catch. That's a real bug rather than an
-            # annotation one, so it keeps its behaviour here and gets its own PR
-            css = cast("str", style.text)
+            # An empty <style></style> has no text, which is the same as having no CSS
+            css = style.text or ""
         except Exception:
             css = ""
 


### PR DESCRIPTION
A student submitting `<style></style>` takes the judge run down:

```python
>>> CssValidator("<html><head><style></style></head><body><p>x</p></body></html>")
TypeError: 'NoneType' object is not iterable
```

<details>

`style.text` is `None` for an empty tag. That assignment sits inside the `try`, so nothing
raises there, but `Rules(css)` is called *after* the `try` and hands the `None` to tinycss2.
And `TestSuite.__post_init__` only catches `CssParsingError`, so this isn't caught downstream
either.

An empty `<style>` means the submission has no CSS, which is what a *missing* `<style>` has
always meant, so it takes the same path.

Found while extending ty over `validators/`. It only became visible once lxml had real types:
before that `style.text` was `Unknown` and nothing could tell it was optional.

</details>

## Testing

```sh
docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w --user root \
  ghcr.io/dodona-edu/dodona-html:latest \
  sh -c "./devel/install_test_deps.sh && ./devel/run-tests.sh"
```

`93 passed, 4 xfailed`, up from 91. Confirmed both tests fail without the fix:

```
FAILED tests/test_validators/test_css_validator.py::TestCssValidator::test_empty_style_tag
tinycss2/parser.py:19: TypeError
```

The second test covers a document with no `<style>` at all, which already worked, so the two
cases are pinned together and can't drift apart again.

Stacked on #281.
