### PR TITLE
Select every ruff rule and ignore what does not fit

### DIFF
--- a/decorators/check_wrappers.py
+++ b/decorators/check_wrappers.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 def fail():
     """Return a Check that always fails"""
     # Local import to avoid circular dependencies
-    from validators.checks import Check
+    from validators.checks import Check  # noqa: PLC0415
 
     def _inner(_: BeautifulSoup) -> bool:
         return False

--- a/decorators/check_wrappers.py
+++ b/decorators/check_wrappers.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import functools
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Concatenate, Protocol, cast
 
-from bs4 import BeautifulSoup
-
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from bs4 import BeautifulSoup
     from bs4.element import Tag
 
     from validators.css_validator import CssValidator

--- a/dodona/dodona_command.py
+++ b/dodona/dodona_command.py
@@ -74,7 +74,9 @@ class DodonaException(Exception):
         self.message = Message(*args, **kwargs) if len(args) > 0 or len(kwargs) > 0 else None
 
 
-class DodonaCommand(ABC):
+# ABC without abstract methods on purpose: every method here has a working default, the
+# base is abstract only in the sense that it should never be entered as a 'with' block itself.
+class DodonaCommand(ABC):  # noqa: B024
     """abstract class, parent of all Dodona commands
     This class provides all shared functionality for the Dodona commands. These commands
     should be used in a Python 'with' block.

--- a/dodona/dodona_command.py
+++ b/dodona/dodona_command.py
@@ -174,10 +174,7 @@ class DodonaCommand(ABC):
         returns True, this function also returns True and the error is not propagated.
         :return: if True, the exception is not propagated
         """
-        if isinstance(exc_val, DodonaException):
-            handled = self.handle_dodona_exception(exc_val)
-        else:
-            handled = False
+        handled = self.handle_dodona_exception(exc_val) if isinstance(exc_val, DodonaException) else False
 
         self.__print_command(self.close_msg())
         return handled

--- a/dodona/dodona_config.py
+++ b/dodona/dodona_config.py
@@ -1,7 +1,7 @@
 """Dodona Judge configuration"""
 
 import json
-import os
+from pathlib import Path
 from types import SimpleNamespace
 from typing import TextIO
 
@@ -59,11 +59,9 @@ class DodonaConfig(SimpleNamespace):
         Also, this Python file (and all other Python judge files) should be located in the 'judge' dir.
         """
         # Make sure that the current working dir is the workdir
-        cwd = os.getcwd()
-        assert os.path.realpath(cwd) == os.path.realpath(self.workdir)
+        assert Path.cwd().resolve() == Path(self.workdir).resolve()
 
         # Make sure that this file is located right below the judge folder
-        script_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-        assert os.path.realpath(script_path) == os.path.realpath(self.judge), (
-            f"{os.path.realpath(script_path)} | {os.path.realpath(self.judge)}"
-        )
+        script_path = Path(__file__).resolve().parent.parent
+        judge_path = Path(self.judge).resolve()
+        assert script_path == judge_path, f"{script_path} | {judge_path}"

--- a/dodona/translator.py
+++ b/dodona/translator.py
@@ -1,6 +1,7 @@
 """translate judge output towards Dodona"""
 
 from enum import Enum, auto
+from typing import ClassVar
 
 from dodona.dodona_command import ErrorType
 
@@ -109,7 +110,7 @@ class Translator:
         """
         return self.text_translations[self.language][message].format(**kwargs)
 
-    error_translations = {
+    error_translations: ClassVar[dict["Translator.Language", dict[ErrorType, str]]] = {
         Language.EN: {
             ErrorType.INTERNAL_ERROR: "Internal error",
             ErrorType.COMPILATION_ERROR: "The code is not valid",
@@ -136,7 +137,7 @@ class Translator:
         },
     }
 
-    text_translations = {
+    text_translations: ClassVar[dict["Translator.Language", dict["Translator.Text", str]]] = {
         Language.EN: {
             Text.MISSING_EVALUATION_FILE: "The evaluator.py and solution.html files are missing.",
             Text.MISSING_CREATE_SUITE: "The evaluator.py file does not implement the 'create_suites(content)' method.",

--- a/exceptions/double_char_exceptions.py
+++ b/exceptions/double_char_exceptions.py
@@ -9,7 +9,9 @@ class DoubleCharError(FeedbackException):
         super().__init__(trans=trans, msg=msg, line=line, pos=pos)
 
 
-class LocatableDoubleCharError(DoubleCharError):
+# The comparisons below exist to sort these by position, not to key them. Adding __hash__
+# would make them hashable, which they are not today and nothing needs.
+class LocatableDoubleCharError(DoubleCharError):  # noqa: PLW1641
     """Exceptions that can be located"""
 
     def __init__(self, trans: Translator, msg: str, line: int, pos: int):

--- a/html_judge.py
+++ b/html_judge.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from dodona.dodona_command import ErrorType, Judgement, Message, MessageFormat, Tab
 from dodona.dodona_config import DodonaConfig
@@ -16,7 +17,9 @@ from utils.messages import (
 )
 from utils.render_ready import prep_render
 from validators import checks
-from validators.checks import TestSuite
+
+if TYPE_CHECKING:
+    from validators.checks import TestSuite
 
 
 def main():
@@ -51,7 +54,6 @@ def main():
                     missing_evaluator_file(config.translator)
                     invalid_suites(judge, config)
                     return
-                # compare(sol, html_content, config.translator)
                 suite = checks._CompareSuite(
                     html_content, solution, config, check_recommended=getattr(config, "recommended", True)
                 )
@@ -66,9 +68,9 @@ def main():
             missing_create_suite(config.translator)
             invalid_suites(judge, config)
             return
-        except Exception as e:
+        except Exception:
             # Something else went wrong
-            invalid_evaluator_file(e)
+            invalid_evaluator_file()
             invalid_suites(judge, config)
             return
 
@@ -109,9 +111,8 @@ def main():
         # Only render out valid HTML on Dodona
         if html_validated:
             title, html = prep_render(html_content, render_css=css_validated)
-            with Tab(f"Rendered{f': {title}' if title else ''}"):
-                with Message(format=MessageFormat.HTML, description=html):
-                    pass
+            with Tab(f"Rendered{f': {title}' if title else ''}"), Message(format=MessageFormat.HTML, description=html):
+                pass
 
         if aborted:
             judge.status = config.translator.error_status(ErrorType.RUNTIME_ERROR)

--- a/html_judge.py
+++ b/html_judge.py
@@ -1,5 +1,5 @@
-import os
 import sys
+from pathlib import Path
 
 from dodona.dodona_command import ErrorType, Judgement, Message, MessageFormat, Tab
 from dodona.dodona_config import DodonaConfig
@@ -46,7 +46,7 @@ def main():
             if evaluator is not None:
                 test_suites: list[TestSuite] = evaluator.create_suites(html_content)
             else:
-                solution = html_loader(os.path.join(config.resources, "./solution.html"))
+                solution = html_loader(str(Path(config.resources) / "solution.html"))
                 if not solution:
                     missing_evaluator_file(config.translator)
                     invalid_suites(judge, config)

--- a/html_judge.py
+++ b/html_judge.py
@@ -54,7 +54,9 @@ def main():
                     missing_evaluator_file(config.translator)
                     invalid_suites(judge, config)
                     return
-                suite = checks._CompareSuite(
+                # Private on purpose: the comparison suite is the judge's fallback when a
+                # teacher ships no evaluator.py, not something an evaluator should build.
+                suite = checks._CompareSuite(  # noqa: SLF001
                     html_content, solution, config, check_recommended=getattr(config, "recommended", True)
                 )
                 test_suites = [suite]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,77 @@ line-length = 120
 target-version = "py313"
 
 [tool.ruff.lint]
-# PYI036 guards the __exit__ signatures: it catches the missing `| None` that made every
-# Dodona 'with' block fail ty's invalid-context-manager check.
-select = ["E", "W", "F", "I", "UP", "PYI036"]
+select = ["ALL"]
+
+ignore = [
+    # validators/ is imported by every exercise's evaluator.py, and README documents
+    # validators/checks.pyi as the autocomplete surface teachers copy into their own repo.
+    # FBT wants boolean parameters keyword-only, which would break get_children(tag, direct=True),
+    # has_content(text, case_insensitive=False), validate_html(allow_warnings=True) and friends
+    # for exercises that are already running in courses.
+    "FBT001",
+    "FBT002",
+    "FBT003",
+    # The stubs exist for their docstrings: that text is what a teacher's editor shows on hover.
+    "PYI021",
+    # Conflicts with the formatter.
+    "COM812",
+    # This repo has no copyright headers.
+    "CPY001",
+    # Exception class names reach student feedback, so renaming them changes what students read.
+    "N818",
+    # The suite is unittest-style by choice. Converting ~430 assertions is its own decision,
+    # not a side effect of turning on a rule set.
+    "PT009",
+    "PT027",
+    # assert is fine here.
+    "S101",
+    # This judge runs student HTML/CSS through bs4, lxml and tinycss2, and runs a teacher's
+    # evaluator.py. Every blind except is a deliberate "turn a crash into feedback" boundary,
+    # and narrowing one means an unexpected library error crashes the judge instead of being
+    # reported. See the noqa'd exec in utils/evaluation_module.py for the other half of that.
+    "BLE001",
+    # All of these fire on functions that already exist. The two argument-count ones sit on
+    # public validators/checks.py methods whose signatures are frozen by checks.pyi, and the
+    # rest sit on the tree comparison, Emmet and CSS parsing functions, where splitting them
+    # up is a refactor with real regression risk rather than a lint fix.
+    "C901",
+    "PLR0911",
+    "PLR0912",
+    "PLR0913",
+    "PLR0915",
+    "PLR0917",
+    # The numbers being compared are HTML and CSS shapes: a hex colour has 3, 4, 6 or 8 digits,
+    # an rgb triple has 3 components, find_parents() always returns 2 extra. Naming those says
+    # less than the literal does. In tests the number is the expectation itself.
+    "PLR2004",
+    # The TODOs here are inline markers next to the exact line they are about. An author, an
+    # issue link, a colon and a sentence would all have to be invented to satisfy these.
+    "FIX002",
+    "TD002",
+    "TD003",
+    "TD004",
+    "TD005",
+    # Deferred, both are a large body of work on their own:
+    # D   937 findings. 277 are missing docstrings (D1xx) and 468 are rewriting summary lines
+    #     to end in a period and start in the imperative mood. Those summaries are the text
+    #     teachers see in autocomplete, so that is a documentation pass, not a formatting one.
+    # ANN 412 findings. Worth doing now that ty checks the whole repo, but it means annotating
+    #     every **kwargs bag and every check-returning method, and it belongs in its own PR
+    #     where the type changes can be reviewed as type changes.
+    "D",
+    "ANN",
+]
 
 [tool.ruff.lint.per-file-ignores]
 # Feedback strings stay on one line so they stay greppable and diff cleanly.
 "dodona/translator.py" = ["E501"]
+# docs/evaluator.py is the example evaluator from the README, deliberately laid out the way a
+# teacher's exercise repo lays it out, so it is not part of a package here.
+"docs/*" = ["INP001"]
+# The tests reach into _bs, _checks and friends on purpose: they assert on what the checks
+# built, and the public surface only tells you whether a check passed.
+"tests/*" = ["SLF001"]
 # Stub signatures and their one-line docstrings don't wrap usefully.
 # checks.pyi is also the one file we hand to other people's tooling: teachers copy it into
 # their own exercise repo so their editor can autocomplete against it. PEP 695 generics
@@ -29,6 +93,10 @@ select = ["E", "W", "F", "I", "UP", "PYI036"]
 # offering completions rather than reporting anything, so the stub stays on the older TypeVar
 # and TypeAlias syntax. The judge's own code runs on 3.13 and doesn't have that constraint.
 "*.pyi" = ["E501", "UP040", "UP047"]
+# Both of these are the teacher-facing signatures themselves. `id` is a parameter name that
+# exercises already pass by keyword, and the Emmet TypeVar shows up by name in the annotations
+# an editor renders, so prefixing it with an underscore changes what teachers read.
+"validators/checks.pyi" = ["A002", "PYI001"]
 
 [tool.pytest.ini_options]
 # All test classes are unittest.TestCase subclasses, which pytest always collects

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,4 @@
-from os import path
+from pathlib import Path
 
 from dodona.translator import Translator
 from utils.file_loaders import html_loader as _html_loader
@@ -6,14 +6,14 @@ from utils.file_loaders import html_loader as _html_loader
 # Location of this test file
 from validators.checks import Check, ChecklistItem, Checks, TestSuite
 
-basepath = path.dirname(__file__)
+basepath = Path(__file__).parent
 
 # Location of html files
-html_dir = path.abspath(path.join(basepath, "../tests/html_files"))
+html_dir = (basepath / "../tests/html_files").resolve()
 
 
 def html_loader(file: str) -> str:
-    return _html_loader(path.join(html_dir, file))
+    return _html_loader(str(html_dir / file))
 
 
 class UnitTestSuite(TestSuite):

--- a/tests/test_utils/test_file_loaders.py
+++ b/tests/test_utils/test_file_loaders.py
@@ -1,6 +1,6 @@
 import tempfile
 import unittest
-from os import path
+from pathlib import Path
 
 from bs4 import BeautifulSoup
 
@@ -12,9 +12,9 @@ class TestFileLoaders(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.TemporaryDirectory()
-        self.file_path = path.join(self.tmpdir.name, "fragment.html")
-        with open(self.file_path, "w") as f:
-            f.write(self.CONTENT)
+        file_path = Path(self.tmpdir.name) / "fragment.html"
+        file_path.write_text(self.CONTENT)
+        self.file_path = str(file_path)
 
     def tearDown(self):
         self.tmpdir.cleanup()

--- a/tests/test_utils/test_flatten.py
+++ b/tests/test_utils/test_flatten.py
@@ -5,7 +5,7 @@ from validators.checks import ChecklistItem, all_of, any_of
 
 
 class TestFlatten(unittest.TestCase):
-    def test_checklistItems(self):
+    def test_checklist_items(self):
         """Constructor of ChecklistItem uses this"""
         suite = UnitTestSuite("test_1")
         body = suite.element("body")
@@ -20,8 +20,9 @@ class TestFlatten(unittest.TestCase):
         self.assertEqual(len(item._checks), 3)
         self.assertTrue(suite.checklist_item(item))
 
-        # Map
-        item = ChecklistItem("", map(lambda i: i.has_tag("div"), body.get_children("div")[:2]))
+        # Map. Deliberately a map object and not a comprehension: flatten_queue has to
+        # accept whatever iterable a teacher hands it, and this is the case for map.
+        item = ChecklistItem("", map(lambda i: i.has_tag("div"), body.get_children("div")[:2]))  # noqa: C417
         self.assertEqual(len(item._checks), 2)
         self.assertTrue(suite.checklist_item(item))
 

--- a/tests/test_validators/test_css_validator.py
+++ b/tests/test_validators/test_css_validator.py
@@ -1,11 +1,13 @@
 import unittest
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from bs4 import BeautifulSoup
-from bs4.element import Tag
 
 from utils.color_converter import Color
 from validators.css_validator import CssValidator
+
+if TYPE_CHECKING:
+    from bs4.element import Tag
 
 html = """<!DOCTYPE html>
 <html lang="en">

--- a/utils/color_converter.py
+++ b/utils/color_converter.py
@@ -1,7 +1,9 @@
 from colour import Color as Col
 
 
-class Color(Col):
+# __eq__ compares the alpha channel that colour.Color doesn't carry. No __hash__ to match:
+# these are only ever compared, never used as a dict key or put in a set.
+class Color(Col):  # noqa: PLW1641
     def __init__(self, val: str):
         val = val.replace(" ", "")
         self.__dict__.__setitem__("alpha", 1.0)

--- a/utils/evaluation_module.py
+++ b/utils/evaluation_module.py
@@ -48,6 +48,7 @@ class EvaluationModule(ModuleType):
             evaluator_module = cls("evaluation", config)
 
             # Build the bytecode & add to the new module
-            exec(evaluator_script, evaluator_module.__dict__)
+            # Running the teacher's evaluator.py is what this class is for
+            exec(evaluator_script, evaluator_module.__dict__)  # noqa: S102
 
             return evaluator_module

--- a/utils/evaluation_module.py
+++ b/utils/evaluation_module.py
@@ -1,4 +1,4 @@
-from os import path
+from pathlib import Path
 from types import ModuleType
 from typing import Optional
 
@@ -33,14 +33,14 @@ class EvaluationModule(ModuleType):
     def build(cls, config: DodonaConfig) -> Optional["EvaluationModule"]:
         """Create a new EvaluationModule from a DodonaConfig configuration"""
         # Create filepath
-        custom_evaluator_path = path.join(config.resources, "./evaluator.py")
+        custom_evaluator_path = Path(config.resources) / "evaluator.py"
 
         # Evaluator doesn't exist, show an exception
-        if not path.exists(custom_evaluator_path):
+        if not custom_evaluator_path.exists():
             return None
 
         # Read raw content of .py file
-        with open(custom_evaluator_path) as fp:
+        with custom_evaluator_path.open() as fp:
             # Compile the code into bytecode
             evaluator_script = compile(fp.read(), "<string>", "exec")
 

--- a/utils/file_loaders.py
+++ b/utils/file_loaders.py
@@ -2,6 +2,9 @@
 util file with functions to load specific types of files
 """
 
+import json
+from pathlib import Path
+
 
 def html_loader(file_path: str, **kwargs) -> str:
     """Utility function to load a HTML file in order to use the content
@@ -16,7 +19,7 @@ def html_loader(file_path: str, **kwargs) -> str:
     if kwargs.get("shorted", True) and not file_path.endswith(".html"):
         file_path += ".html"
 
-    with open(file_path) as file:
+    with Path(file_path).open() as file:
         content = file.read()
 
         if kwargs.get("wrap_head", False):
@@ -42,7 +45,5 @@ def json_loader(file_path: str, **kwargs) -> dict:
     if kwargs.get("shorted", True) and not file_path.endswith(".json"):
         file_path += ".json"
 
-    with open(file_path) as f:
-        import json
-
+    with Path(file_path).open() as f:
         return json.load(f)

--- a/utils/messages.py
+++ b/utils/messages.py
@@ -17,8 +17,12 @@ def invalid_suites(judge: SimpleNamespace, config: DodonaConfig):
     judge.accepted = False
 
 
-def invalid_evaluator_file(exception: Exception):
-    """Show the teacher a message saying that their evaluator file is invalid"""
+def invalid_evaluator_file():
+    """Show the teacher a message saying that their evaluator file is invalid
+
+    Takes no exception: it reads the one currently being handled off format_exc(),
+    so it only says anything useful from inside an except block.
+    """
     with Message(permission=MessagePermission.STAFF, description=traceback.format_exc(), format=MessageFormat.CODE):
         pass
 

--- a/utils/regexes.py
+++ b/utils/regexes.py
@@ -1,7 +1,10 @@
 import re
-from collections import namedtuple
+from typing import NamedTuple
 
-Regex = namedtuple("Regex", "pattern flags")
+
+class Regex(NamedTuple):
+    pattern: str
+    flags: re.RegexFlag
 
 
 # Has to be the first non-empty line, ignoring comments

--- a/utils/render_ready.py
+++ b/utils/render_ready.py
@@ -1,10 +1,12 @@
 from ntpath import basename
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import bs4
-from bs4.element import Tag
 
 from validators.css_validator import Rule, Rules
+
+if TYPE_CHECKING:
+    from bs4.element import Tag
 
 
 def prep_render(html_content: str, render_css: bool) -> tuple[str, str]:

--- a/validators/checks.py
+++ b/validators/checks.py
@@ -17,12 +17,14 @@ from dodona.dodona_config import DodonaConfig
 from dodona.translator import Translator
 from exceptions.double_char_exceptions import LocatableDoubleCharError, MultipleMissingCharsError
 from exceptions.html_exceptions import LocatableHtmlValidationError, Warnings
+from exceptions.structure_exceptions import NotTheSame
 from exceptions.utils import EvaluationAborted
 from utils.flatten import flatten_queue
 from utils.html_navigation import compare_content, contains_comment, find_child, find_emmet, match_emmet
 from utils.regexes import doctype_re
 from validators.css_validator import AmbiguousXpath, CssParsingError, CssValidator, ElementNotFound, Rule
 from validators.html_validator import HtmlValidator
+from validators.structure_validator import compare, get_similarity
 
 # Custom type hints
 Emmet = TypeVar("Emmet", bound=str)
@@ -812,7 +814,9 @@ class ChecklistItem:
         # Flatten the list of checks and store in internal list
         self._checks = flatten_queue(*checks)
 
-    def _process_one(self, check: Check, bs: BeautifulSoup, language: str) -> bool:
+    # language is unused here, but it is part of the signature ChecklistItem subclasses
+    # override, and VerboseChecklistItem does use it to pick the right translation.
+    def _process_one(self, check: Check, bs: BeautifulSoup, language: str) -> bool:  # noqa: ARG002
         """Process a single check inside of this item
         Inner function to make future modifications cleaner, and allows a bit of abstraction
         """
@@ -959,7 +963,8 @@ class TestSuite:
         """Create a new ChecklistItem, the check will compare the submission to the emmet expression.
         The emmet expression is seen as the minimal required elements/attributes, so the submission may contain more
         or equal elements"""
-        from utils.emmet import emmet_to_check
+        # Local import: utils.emmet imports this module at the top for Check and Element
+        from utils.emmet import emmet_to_check  # noqa: PLC0415
 
         # Add multiple emmet checks under one main item
         emmet_checks = [emmet_to_check(e, self) for e in emmets]
@@ -1027,9 +1032,6 @@ class TestSuite:
         """Compare the submission to the solution html."""
 
         def _inner(_: BeautifulSoup):
-            from exceptions.structure_exceptions import NotTheSame
-            from validators.structure_validator import compare, get_similarity
-
             try:
                 compare(solution, self.content, translator, **kwargs)
             except NotTheSame as err:

--- a/validators/checks.py
+++ b/validators/checks.py
@@ -276,16 +276,10 @@ class Element:
         element = cast("Tag", self._element)
 
         def _inner(_: BeautifulSoup) -> bool:
-            children = element.children
-
-            for child in children:
-                # Child is a text instance which is not allowed
-                # Empty tags shouldn't count as text, but for some reason bs4
-                # still picks these up so they're filtered out as well
-                if isinstance(child, NavigableString) and child.text.strip():
-                    return False
-
-            return True
+            # A text instance among the children is not allowed. Empty tags shouldn't count
+            # as text, but for some reason bs4 still picks these up so they're filtered out
+            # as well.
+            return not any(isinstance(child, NavigableString) and child.text.strip() for child in element.children)
 
         return Check(_inner)
 
@@ -294,9 +288,7 @@ class Element:
         # Only reached from methods that @html_check has already guarded
         element = cast("Tag", self._element)
 
-        attribute = element.get(attr.lower())
-
-        return attribute
+        return element.get(attr.lower())
 
     def _compare_attribute_list(
         self,
@@ -321,7 +313,7 @@ class Element:
 
         if case_insensitive:
             value = value.lower()
-            attribute = list(map(lambda x: x.lower(), attribute))
+            attribute = [x.lower() for x in attribute]
 
         # Exact match
         if mode == 0:
@@ -333,11 +325,7 @@ class Element:
 
         # Match regex
         if mode == 2:
-            for v in attribute:
-                if re.search(value, v, flags) is not None:
-                    return True
-
-            return False
+            return any(re.search(value, v, flags) is not None for v in attribute)
 
         # Possible future modes
         return False
@@ -430,11 +418,7 @@ class Element:
                 return False
 
             # Check if all headers have the same content in the same order
-            for i in range(len(header)):
-                if not compare_content(header[i], ths[i].text):
-                    return False
-
-            return True
+            return all(compare_content(header[i], ths[i].text) for i in range(len(header)))
 
         return Check(_inner)
 
@@ -511,12 +495,7 @@ class Element:
             if len(tds) != len(row):
                 return False
 
-            for i in range(len(row)):
-                # Text doesn't match
-                if not compare_content(row[i], tds[i].text, case_insensitive):
-                    return False
-
-            return True
+            return all(compare_content(row[i], tds[i].text, case_insensitive) for i in range(len(row)))
 
         return Check(_inner)
 
@@ -575,7 +554,7 @@ class Element:
             if spl.netloc:
                 # Ignore www. in the start to allow the arguments to be shorter
                 netloc = spl.netloc.lower().removeprefix("www.")
-                return netloc not in list(map(lambda x: x.lower(), allowed_domains))
+                return netloc not in [x.lower() for x in allowed_domains]
 
             return False
 
@@ -622,10 +601,7 @@ class Element:
                 # find_parents() always returns the entire document as well,
                 # even when the current element is the root
                 # So at least 2 parents are required
-                if len(parents) <= 2:
-                    current_element = None
-                else:
-                    current_element = parents[0]
+                current_element = None if len(parents) <= 2 else parents[0]
 
         return prop_value
 
@@ -750,7 +726,8 @@ class ElementContainer:
         # Teachers write these indexes by hand, so the runtime check stays even though
         # the overloads above already rule it out for anything that type-checks
         if not isinstance(item, (int, slice)):
-            raise TypeError(f"Key {item} was of type {type(item).__name__}, not int or slice.")
+            msg = f"Key {item} was of type {type(item).__name__}, not int or slice."
+            raise TypeError(msg)
 
         # Out of range
         if isinstance(item, int) and item >= self._size:
@@ -768,7 +745,7 @@ class ElementContainer:
     def from_tags(cls, tags: list[Tag], css_validator: CssValidator | None) -> "ElementContainer":
         """Construct a container from a list of bs4 Tag instances"""
         # id is not one of the attributes bs4 splits into a list, so it is never a list here
-        elements = list(map(lambda x: Element(x.name, cast("str | None", x.get("id", None)), x, css_validator), tags))
+        elements = [Element(x.name, cast("str | None", x.get("id", None)), x, css_validator) for x in tags]
         return ElementContainer(elements)
 
     def get(self, index: int) -> Element:
@@ -984,11 +961,8 @@ class TestSuite:
         or equal elements"""
         from utils.emmet import emmet_to_check
 
-        emmet_checks = []
-
         # Add multiple emmet checks under one main item
-        for e in emmets:
-            emmet_checks.append(emmet_to_check(e, self))
+        emmet_checks = [emmet_to_check(e, self) for e in emmets]
 
         self.make_item(message, *emmet_checks)
 

--- a/validators/css_validator.py
+++ b/validators/css_validator.py
@@ -72,8 +72,8 @@ def _get_xpath(selector: str) -> str:
     try:
         # TODO filter out pseudo-elements (like or ::after)
         return GenericTranslator().css_to_xpath(selector)
-    except SelectorError:
-        raise CssParsingError
+    except SelectorError as err:
+        raise CssParsingError from err
 
 
 class Rule:
@@ -98,8 +98,8 @@ class Rule:
         if self.is_color():
             try:
                 self.color = Color(self.value_str)
-            except (IndexError, ValueError):
-                raise CssParsingError
+            except (IndexError, ValueError) as err:
+                raise CssParsingError from err
 
     def __repr__(self):
         return f"(Rule: {self.selector_str} | {self.name} {self.value} {'important' if self.important else ''})"
@@ -216,14 +216,13 @@ class Rules:
         r: Rule
         # find all rules defined for the solution element for the specified key
         for r in reversed(self.rules):
-            if r.name == key:
-                if r.pseudo == pseudo:
-                    for element in cast("list[_Element]", root.xpath(r.xpath)):
-                        if element == solution_element:
-                            if r.important:
-                                imp.append(r)
-                            else:
-                                rs.append(r)
+            if r.name == key and r.pseudo == pseudo:
+                for element in cast("list[_Element]", root.xpath(r.xpath)):
+                    if element == solution_element:
+                        if r.important:
+                            imp.append(r)
+                        else:
+                            rs.append(r)
 
         # check if there are rules containing !important
         if imp:
@@ -260,8 +259,7 @@ class Rules:
                     else:
                         by_keyword[r.name][1].append(r)
 
-        for key in by_keyword:
-            imp, rs = by_keyword[key]
+        for imp, rs in by_keyword.values():
             # check if there are rules containing !important
             if imp:
                 rs = imp

--- a/validators/css_validator.py
+++ b/validators/css_validator.py
@@ -259,10 +259,9 @@ class Rules:
                     else:
                         by_keyword[r.name][1].append(r)
 
-        for imp, rs in by_keyword.values():
-            # check if there are rules containing !important
-            if imp:
-                rs = imp
+        for imp, non_imp in by_keyword.values():
+            # rules containing !important win from the ones that don't
+            rs = imp or non_imp
             # get the most specific rule or the one that was defined the latest if multiple with the same specificity
             dom_rule = rs[0]  # the dominating rule
             for r in rs:
@@ -278,9 +277,12 @@ class Rules:
         dom_rule: Rule | None = None
         rule: Rule
         for rule in self.rules:
-            if rule.selector_str == css_selector and rule.name == key:
-                if dom_rule is None or rule.specificity > dom_rule.specificity:
-                    dom_rule = rule
+            if (
+                rule.selector_str == css_selector
+                and rule.name == key
+                and (dom_rule is None or rule.specificity > dom_rule.specificity)
+            ):
+                dom_rule = rule
         return dom_rule
 
 

--- a/validators/double_chars_validator.py
+++ b/validators/double_chars_validator.py
@@ -20,10 +20,9 @@ class DoubleChar:
     pos: int
 
     def __repr__(self) -> str:
+        s = ""
         if self.is_unambiguous:
             s = " open" if self.is_open() else " close"
-        else:
-            s = ""
 
         return f"<{self.type}{s}>"
 

--- a/validators/double_chars_validator.py
+++ b/validators/double_chars_validator.py
@@ -32,7 +32,7 @@ class DoubleChar:
         """
         c = copy.copy(self)
         if self.is_unambiguous:
-            c._is_open = is_open
+            c._is_open = is_open  # noqa: SLF001
         c.line = line
         c.pos = pos
         return c
@@ -196,7 +196,7 @@ class DoubleCharsValidator:
             # don't check inside
             if not el.check_inside:
                 wus = el
-                wus._is_open = True
+                wus._is_open = True  # noqa: SLF001
             else:
                 wus = None
                 stack.append(el)

--- a/validators/html_validator.py
+++ b/validators/html_validator.py
@@ -1,7 +1,6 @@
 from functools import lru_cache
 from html.parser import HTMLParser
-from os import path
-from pathlib import PureWindowsPath
+from pathlib import Path, PureWindowsPath
 from typing import cast
 
 from dodona.translator import Translator
@@ -24,7 +23,7 @@ from utils.file_loaders import html_loader, json_loader
 from validators.double_chars_validator import DoubleCharsValidator
 
 # Location of this test file
-base_path = path.dirname(__file__)
+base_path = Path(__file__).parent
 # keynames for the json
 REQUIRED_ATR_KEY = "required_attributes"
 RECOMMENDED_ATR_KEY = "recommended_attributes"
@@ -77,7 +76,7 @@ class HtmlValidator(HTMLParser):
         self.warnings = Warnings(self.translator)
         self.tag_stack = []
         self.double_chars_validator = DoubleCharsValidator(translator)
-        self.valid_dict = json_loader(path.abspath(path.join(base_path, "html_tags_attributes.json")))
+        self.valid_dict = json_loader(str((base_path / "html_tags_attributes.json").resolve()))
         self.check_required = kwargs.get("required", True)
         self.check_recommended = kwargs.get("recommended", True)
         self.check_nesting = kwargs.get("nesting", True)

--- a/validators/html_validator.py
+++ b/validators/html_validator.py
@@ -183,12 +183,15 @@ class HtmlValidator(HTMLParser):
                     MissingOpeningTagError(trans=self.translator, tag=tag, line=self.getpos()[0], pos=self.getpos()[1])
                 )
 
-    @lru_cache
+    # lru_cache on a method keeps the instance alive for as long as the cache does. A judge
+    # process handles one submission and exits, so the validator it holds on to is one that
+    # was going to live that long anyway.
+    @lru_cache  # noqa: B019
     def _is_void_tag(self, tag: str) -> bool:
         """indicates whether the tag its corresponding closing tag is omittable or not"""
         return VOID_KEY in self.valid_dict[tag] and self.valid_dict[tag][VOID_KEY]
 
-    @lru_cache
+    @lru_cache  # noqa: B019
     def _valid_tag(self, tag: str):
         """validate that a tag is a valid HTML tag (if a tag isn't allowed, this wil also raise an exception"""
         if tag not in self.valid_dict:

--- a/validators/structure_validator.py
+++ b/validators/structure_validator.py
@@ -79,9 +79,7 @@ def compare(solution_str: str, submission_str: str, trans: Translator, **kwargs)
                 dummies.remove(b)
             elif exact_match:
                 return False
-        if dummies or exact:
-            return False
-        return True
+        return not (dummies or exact)
 
     queue = [(solution, submission)]
     while queue:
@@ -111,28 +109,25 @@ def compare(solution_str: str, submission_str: str, trans: Translator, **kwargs)
                 trans=trans, msg=trans.translate(Translator.Text.TAGS_DIFFER), line=node_sub.sourceline, pos=-1
             )
         # check attributes if wanted
-        if check_attributes:
-            if not attrs_a_contains_attrs_b(node_sol.attrib, node_sub.attrib, True):
-                raise NotTheSame(
-                    trans=trans,
-                    msg=trans.translate(Translator.Text.ATTRIBUTES_DIFFER),
-                    line=node_sub.sourceline,
-                    pos=-1,
-                )
-        if check_minimal_attributes:
-            if not attrs_a_contains_attrs_b(node_sol.attrib, node_sub.attrib, False):
-                raise NotTheSame(
-                    trans=trans,
-                    msg=trans.translate(Translator.Text.NOT_ALL_ATTRIBUTES_PRESENT),
-                    line=node_sub.sourceline,
-                    pos=-1,
-                )
+        if check_attributes and not attrs_a_contains_attrs_b(node_sol.attrib, node_sub.attrib, True):
+            raise NotTheSame(
+                trans=trans,
+                msg=trans.translate(Translator.Text.ATTRIBUTES_DIFFER),
+                line=node_sub.sourceline,
+                pos=-1,
+            )
+        if check_minimal_attributes and not attrs_a_contains_attrs_b(node_sol.attrib, node_sub.attrib, False):
+            raise NotTheSame(
+                trans=trans,
+                msg=trans.translate(Translator.Text.NOT_ALL_ATTRIBUTES_PRESENT),
+                line=node_sub.sourceline,
+                pos=-1,
+            )
         # check content if wanted
-        if check_contents:
-            if node_sol.text != "DUMMY" and not compare_content(node_sol.text, node_sub.text):
-                raise NotTheSame(
-                    trans=trans, msg=trans.translate(Translator.Text.CONTENTS_DIFFER), line=node_sub.sourceline, pos=-1
-                )
+        if check_contents and node_sol.text != "DUMMY" and not compare_content(node_sol.text, node_sub.text):
+            raise NotTheSame(
+                trans=trans, msg=trans.translate(Translator.Text.CONTENTS_DIFFER), line=node_sub.sourceline, pos=-1
+            )
         # check css
         # Both validators are set together, and check_css only stays True when both made
         # it through the block above, but that is a chain of assignments away from here
@@ -148,14 +143,15 @@ def compare(solution_str: str, submission_str: str, trans: Translator, **kwargs)
                             line=node_sub.sourceline,
                             pos=-1,
                         )
-                    if rs_sol[r_key].value_str != rs_sub[r_key].value_str:
-                        if not (rs_sol[r_key].is_color() and rs_sol[r_key].has_color(rs_sub[r_key].value_str)):
-                            raise NotTheSame(
-                                trans=trans,
-                                msg=trans.translate(Translator.Text.STYLES_DIFFER, tag=node_sub.tag),
-                                line=node_sub.sourceline,
-                                pos=-1,
-                            )
+                    if rs_sol[r_key].value_str != rs_sub[r_key].value_str and not (
+                        rs_sol[r_key].is_color() and rs_sol[r_key].has_color(rs_sub[r_key].value_str)
+                    ):
+                        raise NotTheSame(
+                            trans=trans,
+                            msg=trans.translate(Translator.Text.STYLES_DIFFER, tag=node_sub.tag),
+                            line=node_sub.sourceline,
+                            pos=-1,
+                        )
         # check whether the children of the nodes have the same amount of children
         node_sol_children = node_sol.getchildren()
         node_sub_children = node_sub.getchildren()
@@ -170,4 +166,4 @@ def compare(solution_str: str, submission_str: str, trans: Translator, **kwargs)
                 pos=-1,
             )
         # reverse children bc for some reason they are in bottom up order (and we want to review top down)
-        queue += zip(reversed(node_sol_children), reversed(node_sub_children))
+        queue += zip(reversed(node_sol_children), reversed(node_sub_children), strict=True)

--- a/validators/structure_validator.py
+++ b/validators/structure_validator.py
@@ -1,3 +1,4 @@
+from html_similarity import structural_similarity, style_similarity
 from lxml.html import HtmlComment, HtmlElement, fromstring
 
 from dodona.translator import Translator
@@ -11,8 +12,6 @@ def get_similarity(sol: str, sub: str) -> tuple[float, float]:
     # Empty submission is 0% similar
     if is_empty_document(sub):
         return 0, 0
-
-    from html_similarity import structural_similarity, style_similarity
 
     a = sol.find("<style")
     b = sub.find("<style")


### PR DESCRIPTION
Last PR in the cycle: enables ALL ruff rules, and ignores what makes sense.

<details>

Second of two, on top of #284 (merged). `pyproject.toml` goes from `select = ["E", "W", "F", "I", "UP", "PYI036"]`
to `select = ["ALL"]` plus an explicit ignore list, so from here a new ruff rule family shows up
as a finding to decide on rather than never showing up at all.

Counts with `ruff@0.16.3`:

| | findings |
| --- | --- |
| `ALL`, raw, on `main` | 2408 |
| `ALL` minus the permanent ignores and minus `D`/`ANN`, on `main` | 251 |
| same, after #284 | 161 |
| same, after this PR | 0 |

Three commits: the pathlib move, the fixes with an obvious answer, then the config plus the
per-site `noqa`s. Reviewing per commit is probably easier than the combined diff.

</details> 

## The ignore list

Every entry has its reason in `pyproject.toml` next to it, and none of them is dead weight:
each still has findings behind it today (I checked by running with only `D`/`ANN` ignored).

The ones that are about this being a judge rather than about style:

- **`FBT001` / `FBT002` / `FBT003`** would make boolean parameters keyword-only across
  `validators/`, which breaks `get_children(tag, direct=True)`, `has_content(text, case_insensitive=False)`
  and `validate_html(allow_warnings=True)` for exercises already running in courses.
- **`PYI021`** the stubs exist *for* their docstrings, that text is the autocomplete a teacher reads.
- **`N818`** exception class names reach student feedback, so renaming them changes what students see.
- **`BLE001`** every blind `except` in here is a "turn a crash into feedback" boundary around
  student HTML/CSS or a teacher's `evaluator.py`. I read all six and none of them is an
  accident, so nothing got narrowed.
- **`C901` + `PLR0911/0912/0913/0915/0917`, and `PLR2004`** all fire on functions that already
  exist. Ignored rather than raised to a threshold: `compare()` sits at complexity 27, and a
  `max-complexity` that lets it through leaves the rule meaning nothing. The two
  argument-count ones are on public `validators/checks.py` methods whose signatures are frozen
  by `checks.pyi` anyway.
- **`FIX002` + `TD002`-`TD005`** the TODOs are inline markers next to the line they are about.
  An author, an issue link, a colon and a sentence would all have to be invented.

Deferred, each with a note in the config saying what it would take: **`D`** (937 findings, of
which 277 missing docstrings and 468 rewriting summary lines that teachers read in autocomplete)
and **`ANN`** (412).

Per-file rather than global: `SLF001` for `tests/*`, `INP001` for `docs/*`, and `A002` + `PYI001`
for `validators/checks.pyi` (the `id` parameter and the `Emmet` TypeVar are both teacher-facing
names). The existing `UP047`/`UP040` entry for `*.pyi` stays where it was.

<details>

## Judgement calls

<details>
<summary>Per-site noqa instead of a fix, reason next to the code</summary>

- `decorators/check_wrappers.py` and `validators/checks.py` keep two local imports (`PLC0415`)
  that break a real cycle: `utils.emmet` imports `validators.checks` at the top. The other four
  local imports turned out not to be circular at all and moved up, which cost 32 ms of import
  time for `html_similarity`.
- `utils/evaluation_module.py` execs the teacher's `evaluator.py` (`S102`). That is the job.
- `validators/html_validator.py` keeps `@lru_cache` on two methods (`B019`). The leak the rule
  warns about is the instance staying alive as long as the cache, and a judge process handles
  one submission and exits.
- `html_judge.py` reaches for `checks._CompareSuite` (`SLF001`), which is private so that
  evaluators don't build it, not so that the judge can't.
- `DoubleChar.create` and `push_stack` set `_is_open` on another instance of the same class
  (`SLF001`).
- `ChecklistItem._process_one` keeps its unused `language` parameter (`ARG002`):
  `VerboseChecklistItem` overrides the method and does use it.
- Two classes define `__eq__` without `__hash__` (`PLW1641`). Adding one would make them
  hashable, which is a behaviour change, and nothing puts them in a set or dict.
</details>

<details>
<summary>Two ruff autofixes I refused</summary>

- `C417` rewrote the `# Map` case in `test_flatten.py` into a generator expression, which made
  it an exact copy of the `# Generator expression` case below it and stopped testing that
  `flatten_queue` accepts a `map` object. Kept as a `map` with a `noqa`.
- `SIM110` wanted `no_loose_text`'s loop to become `all(not (...))`. Written as `not any(...)`
  instead, same thing without the double negative.
</details>

## Two things I noticed and did not touch

- **`utils/color_converter.py` drops the alpha channel for `rgba()` and `hsla()`.**
  `parse_quadruple` parses the alpha and the result is thrown away, so those colours keep the
  `1.0` set at the top of `__init__`, while `#RRGGBBAA` and `#RGBA` do apply theirs. Since
  `Color.__eq__` compares `alpha`, `rgba(0, 0, 0, 0.5)` currently compares equal to
  `rgb(0, 0, 0)`. That is what `RUF059` flagged. Left alone here, it wants a fix with a
  regression test, not a lint pass. I can open an issue if you want.
- **`@lru_cache` on `HtmlValidator._valid_tag`** caches the `None` return, so `self.error(...)`
  only fires the first time a given invalid tag is seen. Might well be deliberate (don't spam
  the same warning), just noting it since I was in there.

</details>

## Testing

```
docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w python:3.13-slim \
  sh -c "./devel/install_deps.sh && ./devel/install_dev_deps.sh && ./devel/check.sh"
```
passes, `ty check .` included and still at zero diagnostics.

```
docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w --user root \
  ghcr.io/dodona-edu/dodona-html:latest \
  sh -c "./devel/install_test_deps.sh && ./devel/run-tests.sh"
```
gives `93 passed, 4 xfailed`, unchanged, and no test was added or removed.

No signature in `validators/checks.pyi` changed: same parameter names, defaults and parameter
sets throughout.
