### PR TITLE
Keep the alpha channel from rgba and hsla

### DIFF
--- a/tests/test_utils/test_color_converter.py
+++ b/tests/test_utils/test_color_converter.py
@@ -24,3 +24,19 @@ class TestColorConverter(unittest.TestCase):
         self.assertEqual(correct, Color("hsl(0, 100%, 50%)"), "test hsl")
 
         self.assertEqual(correct, Color("hsla(0, 100%, 50%,1)"), "test hsla")
+
+    def test_alpha_is_kept_from_rgba_and_hsla(self):
+        """rgba() and hsla() carry an alpha, and it has to survive parsing"""
+        # The alpha was parsed and then dropped, so these all looked fully opaque
+        self.assertAlmostEqual(Color("rgba(0,0,0,0.5)").alpha, 0.5)
+        self.assertAlmostEqual(Color("hsla(0,0%,0%,0.25)").alpha, 0.25)
+
+        # Which made a half-transparent black compare equal to an opaque one
+        self.assertNotEqual(Color("rgba(0,0,0,0.5)"), Color("rgb(0,0,0)"))
+
+        # An alpha of 1 still means the same colour as the triple form
+        self.assertEqual(Color("rgba(0,0,0,1)"), Color("rgb(0,0,0)"))
+
+        # Forms without an alpha are unaffected and stay opaque
+        self.assertAlmostEqual(Color("rgb(1,2,3)").alpha, 1.0)
+        self.assertAlmostEqual(Color("#ff0000").alpha, 1.0)

--- a/utils/color_converter.py
+++ b/utils/color_converter.py
@@ -37,12 +37,16 @@ class Color(Col):
                 super().__init__(val[:-2])
         elif val.startswith("rgba"):
             triple, alpha = parse_quadruple(val[4:])
+            # Set before super().__init__, the same way the hex branches above do
+            self.__dict__.__setitem__("alpha", alpha)
             super().__init__(rgb=triple)
         elif val.startswith("rgb"):
             triple = parse_triple(val[3:])
             super().__init__(rgb=triple)
         elif val.startswith("hsla"):
             triple, alpha = parse_quadruple(val[4:])
+            # Set before super().__init__, the same way the hex branches above do
+            self.__dict__.__setitem__("alpha", alpha)
             super().__init__(hsl=triple)
         elif val.startswith("hsl"):
             triple = parse_triple(val[3:])


### PR DESCRIPTION
Fixes a bug found by ruff causing the alpha channel to get dropped from rgba and hsla.

<details>

`rgba()` and `hsla()` colours came out fully opaque. `parse_quadruple` parses the alpha and
returns it, and the caller unpacked it into a local it never used:

```python
triple, alpha = parse_quadruple(val[4:])
super().__init__(rgb=triple)
```

The hex branches a few lines above do assign it onto the instance, so the two spellings of the
same colour disagreed:

```
rgba(0, 0, 0, 0.5)  ->  alpha 1.0     (wrong)
#00000080           ->  alpha 0.502   (right)
```

`Color.__eq__` compares alpha, so a half-transparent black compared **equal** to an opaque one.
Any checklist item comparing against an `rgba()` value has been matching colours it shouldn't.

The fix assigns the parsed alpha the same way the hex branches do, before `super().__init__`.

Found by ruff's `RUF059` while enabling the full rule set: it flagged `alpha` as an unpacked
variable that is never read.

</details>

## Testing

```sh
docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w --user root \
  ghcr.io/dodona-edu/dodona-html:latest \
  sh -c "./devel/install_test_deps.sh && ./devel/run-tests.sh"
```

`94 passed, 4 xfailed`, up from 93. Behaviour before and after:

```
rgba alpha:                       1.0    ->  0.5
hsla alpha:                       1.0    ->  0.25
rgba(0,0,0,0.5) == rgb(0,0,0):    True   ->  False
rgba(0,0,0,1)   == rgb(0,0,0):    True   ->  True
rgb(1,2,3) alpha:                 1.0    ->  1.0
```

Worth noting why this survived: the existing `test_conversion_red` does cover `rgba` and `hsla`,
but every one of its cases uses alpha `1`, which is the one value where dropping the alpha makes
no difference. The new test covers the values that do.
