### PR TITLE
Stop dependabot bumping the pins that mirror the image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,17 @@ updates:
     open-pull-requests-limit: 99
     labels:
       - dependencies
+    # requirements.txt mirrors what dodona-edu/docker-images builds into
+    # ghcr.io/dodona-edu/dodona-html:latest, so those runtime pins are owned by that repo,
+    # not this one. Dependabot must not touch them. This is an allow-list rather than an
+    # ignore-list on purpose: it fails safe. If the image later gains a runtime dependency,
+    # it's ignored by default here, whereas a deny-list would silently start proposing bumps
+    # for it until someone remembered to add it to the list.
+    allow:
+      - dependency-name: "ruff"
+      - dependency-name: "ty"
+      - dependency-name: "pytest*"
+      - dependency-name: "coverage"
     groups:
       pytest:
         patterns:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+      - name: Check requirements.txt matches the image
+        run: python devel/check_requirements_match_image.py
       - name: Install test dependencies
         run: ./devel/install_test_deps.sh
       - name: Run tests

--- a/devel/check_requirements_match_image.py
+++ b/devel/check_requirements_match_image.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Check that requirements.txt matches what's actually installed in the judge image.
+
+requirements.txt mirrors dodona-edu/docker-images/dodona-html.dockerfile: it documents what
+ghcr.io/dodona-edu/dodona-html:latest ships, it isn't a source of truth that pip installs from
+in production. The judge runs with whatever the image has installed, so if requirements.txt
+drifts from the image, it starts lying about what's actually running.
+
+This script can't inspect the image directly, so instead it relies on where it runs: in CI it
+runs as a step inside a container built from that very image (see
+.github/workflows/integration_test.yml), so "importable/installed in the current Python
+environment" *is* "what the image ships" -- the actual source of truth. It parses
+requirements.txt, looks up each pinned package's installed version via importlib.metadata, and
+reports every mismatch (missing package or version drift) before exiting non-zero.
+"""
+
+import sys
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+REQUIREMENTS_PATH = Path(__file__).resolve().parent.parent / "requirements.txt"
+
+
+def parse_requirements(path: Path) -> dict[str, str]:
+    """Parse a requirements.txt file into a mapping of package name to pinned version.
+
+    Blank lines are skipped, inline `#` comments are stripped, and lines that are then
+    empty are skipped too. Remaining lines are expected to be `name==version` pins.
+    """
+    pins: dict[str, str] = {}
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        name, _, want = line.partition("==")
+        pins[name.strip()] = want.strip()
+    return pins
+
+
+def find_mismatches(pins: dict[str, str]) -> list[str]:
+    """Compare pinned versions against what's installed, returning a list of problem descriptions."""
+    problems: list[str] = []
+    for name, want in pins.items():
+        try:
+            have = version(name)
+        except PackageNotFoundError:
+            problems.append(f"{name}: pinned {want}, NOT INSTALLED in the image")
+            continue
+        if have != want:
+            problems.append(f"{name}: requirements.txt says {want}, image has {have}")
+    return problems
+
+
+def main() -> None:
+    pins = parse_requirements(REQUIREMENTS_PATH)
+    problems = find_mismatches(pins)
+
+    if problems:
+        print("requirements.txt does not match the image:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        raise SystemExit(1)
+
+    print(f"requirements.txt matches the {len(pins)} package(s) installed in the image.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,9 @@ ignore = [
 # The tests reach into _bs, _checks and friends on purpose: they assert on what the checks
 # built, and the public surface only tells you whether a check passed.
 "tests/*" = ["SLF001"]
+# devel/ holds scripts CI runs directly, so printing is how they report. They are also not
+# an importable package.
+"devel/*" = ["T201", "INP001"]
 # Stub signatures and their one-line docstrings don't wrap usefully.
 # checks.pyi is also the one file we hand to other people's tooling: teachers copy it into
 # their own exercise repo so their editor can autocomplete against it. PEP 695 generics


### PR DESCRIPTION
**TODO (author) — drafted by Claude: proofread, verify and remove this line.**

Dependabot has five PRs open (#264 to #268) wanting to bump `beautifulsoup4`, `tinycss2`,
`html-similarity`, `cssselect` and `lxml` in `requirements.txt`. None of them should be merged,
and it will keep opening them every month.

`requirements.txt` records what `ghcr.io/dodona-edu/dodona-html:latest` ships. It isn't what
production installs from, the image is. Its own header says a differing pin "is a lie about
production". So a bump there doesn't upgrade anything, it just makes the file wrong.

It isn't only cosmetic either: `lint.yml` installs `requirements.txt` so `ty` can resolve
imports. Merging #264 would leave ty type-checking against beautifulsoup4 4.15 while the judge
runs 4.13.3, which is exactly the production-versus-CI gap this series set out to close.

## Two halves

**An allow-list, not an ignore-list.** Dependabot's pip entry covers every `requirements*.txt`
under its directory and can't be scoped per file, so the fix has to name dependencies rather
than paths. `requirements-dev.txt` and `requirements-test.txt` are genuinely ours and should
keep flowing, so `ruff`, `ty`, `pytest*` and `coverage` are allowed and everything else is not.

Allow-list rather than ignore-list because it fails safe: if the image gains a runtime
dependency later, it's ignored by default. A deny-list would quietly start proposing bumps for
it until someone remembered to extend the list, which is the same class of silent drift.

**A check that the mirror is accurate.** Muting Dependabot stops the noise but leaves the real
hazard untouched: nothing catches `requirements.txt` disagreeing with the image, and that
failure is silent. `devel/check_requirements_match_image.py` compares each pin against
`importlib.metadata.version()`, and the integration job runs it inside the image it already
pulls. No cross-repo fetch, no parsing the dockerfile, and the authority is the image itself
rather than a file describing it.

When docker-images next bumps beautifulsoup4, CI now says so.

## Testing

```sh
docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w --user root \
  ghcr.io/dodona-edu/dodona-html:latest python devel/check_requirements_match_image.py
```

```
requirements.txt matches the 7 package(s) installed in the image.
```

A check that can't fail is worth nothing, so it was made to fail on purpose: pinning
`beautifulsoup4==4.99.9` and adding a package that doesn't exist gives

```
requirements.txt does not match the image:
  - beautifulsoup4: requirements.txt says 4.99.9, image has 4.13.3
  - totally-not-a-real-package: pinned 1.0.0, NOT INSTALLED in the image
```

exit 1, reporting every problem rather than stopping at the first.

`./devel/check.sh` passes and the suite is unchanged at `94 passed, 4 xfailed`. `devel/*` picks
up a per-file ignore for `T201` and `INP001`: these are scripts CI runs directly, so printing is
how they report, and they aren't an importable package.

Once this is in, #264 to #268 can be closed as not applicable, along with #243 and #249, which
predate this work and are now obsolete.
