### PR TITLE
Align devel tooling with judge-sql and judge-turtle

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,23 @@ In a lot of cases you're going to want the students to write _something_ or to g
 
 ## Testing
 
+The following command can be used to run the tests:
+
+```bash
+$ devel/run-tests.sh
+============================= test session starts ==============================
+platform darwin -- Python 3.13.2, pytest-9.1.1, pluggy-1.6.0
+...
+.................x............x.....x...x............................... [ 73%]
+..........................                                               [100%]
+================================ tests coverage ================================
+_______________ coverage: platform darwin, python 3.13.2-final-0 _______________
+
+Coverage HTML written to dir htmlcov
+Coverage XML written to file coverage.xml
+================== 94 passed, 4 xfailed, 8 warnings in 1.74s ===================
+```
+
 ## Contributors
 
 * **S. De Clercq**

--- a/devel/format.sh
+++ b/devel/format.sh
@@ -5,4 +5,5 @@ ROOT="$(dirname "$(dirname "$0")")"
 
 cd "$ROOT"
 
+ruff check --fix .
 ruff format .


### PR DESCRIPTION
Last round before we start thinking about the dependabot updates. This PR closes some gaps between the tooling compares to the sql and turtle judge:

1. format.sh now also runs `ruff check --fix`
2. fills in the empty `## Testing` section from the readme

<details>

Aligns two small tooling gaps in judge-html with judge-sql and judge-turtle.

- `devel/format.sh` now also runs `ruff check --fix .` before `ruff format .`, matching the other two repos. Ran it locally after adding the line and it produced no working-tree changes.
- Filled in the previously-empty `## Testing` section in README.md, mirroring judge-sql's version: the `devel/run-tests.sh` command plus real sample output.

<details>
<summary>Test run used for the README sample</summary>

```
$ devel/run-tests.sh
============================= test session starts ==============================
platform darwin -- Python 3.13.2, pytest-9.1.1, pluggy-1.6.0
...
.................x............x.....x...x............................... [ 73%]
..........................                                               [100%]
================================ tests coverage ================================
_______________ coverage: platform darwin, python 3.13.2-final-0 _______________

Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml
================== 94 passed, 4 xfailed, 8 warnings in 1.74s ===================
```

</details>

## Manual testing

1. Run `mise x -- ./devel/format.sh` and confirm `git status` is clean.
3. Run `mise x -- ./devel/check.sh` and confirm the ruff checks pass.

</details>